### PR TITLE
Argument list correction + Alphabets of integers

### DIFF
--- a/src/Alphabet.jl
+++ b/src/Alphabet.jl
@@ -111,7 +111,7 @@ function set_inversion!(A::Alphabet{T}, x::T, y::T) where T
 end
 
 """
-    function getindexbyelement(A::Alphabet{T}, x::T) where T
+    function getindexbysymbol(A::Alphabet{T}, x::T) where T
 
 Returns the position of the symbol `x` in the alphabet `A`.
 

--- a/src/Alphabet.jl
+++ b/src/Alphabet.jl
@@ -111,9 +111,36 @@ function set_inversion!(A::Alphabet{T}, x::T, y::T) where T
 end
 
 """
-    function Base.getindex(A::Alphabet{T}, x::T) where T
+    function getindexbyelement(A::Alphabet{T}, x::T) where T
 
 Returns the position of the symbol `x` in the alphabet `A`.
+
+# Example
+```julia-repl
+julia> A = Alphabet{String}()
+Empty alphabet of String
+
+julia> push!(A, "a", "b", "c")
+Alphabet of String:
+    1. "a"
+    2. "b"
+    3. "c"
+
+julia> getindexbyelement(A, "c")
+3
+```
+"""
+function getindexbyelement(A::Alphabet{T}, x::T) where T
+    if (index = findfirst(symbol -> symbol == x, A.alphabet)) == nothing
+        throw(DomainError("Element '$(x)' not found in the alphabet"))
+    end
+    index
+end
+
+"""
+    function Base.getindex(A::Alphabet{T}, x::T) where T
+
+Returns the position of the symbol `x` in the alphabet `A`. If `T` is equal to `Integer`, use `getindexbyelement`.
 
 # Example
 ```julia-repl
@@ -130,12 +157,7 @@ julia> A["c"]
 3
 ```
 """
-function Base.getindex(A::Alphabet{T}, x::T) where T
-    if (index = findfirst(symbol -> symbol == x, A.alphabet)) == nothing
-        throw(DomainError("Element '$(x)' not found in the alphabet"))
-    end
-    index
-end
+Base.getindex(A::Alphabet{T}, x::T) where T = getindexbyelement(A, x)
 
 
 """

--- a/src/Alphabet.jl
+++ b/src/Alphabet.jl
@@ -126,7 +126,7 @@ Alphabet of String:
     2. "b"
     3. "c"
 
-julia> getindexbyelement(A, "c")
+julia> getindexbysymbol(A, "c")
 3
 ```
 """

--- a/src/Alphabet.jl
+++ b/src/Alphabet.jl
@@ -12,7 +12,10 @@ Empty alphabet of String
 mutable struct Alphabet{T}
     alphabet::Vector{T}
     inversions::Vector{Integer}
-    function Alphabet{T}() where T
+    function Alphabet{T}(; safe = true) where T
+        if safe && T <: Integer
+            error("I am sorry to say that, but it is not allowed for alphabet symbols to be integers. If you do *really* know what you are doing, call the constructor with `safe = false`.")
+        end
         new(Vector{T}[], Vector{Integer}[])
     end
 end
@@ -140,7 +143,7 @@ end
 """
     function Base.getindex(A::Alphabet{T}, x::T) where T
 
-Returns the position of the symbol `x` in the alphabet `A`. If `T` is equal to `Integer`, use `getindexbyelement`.
+Returns the position of the symbol `x` in the alphabet `A`. If you, by any chance, work with the alphabet of integers, use `getindexbysymbol`.
 
 # Example
 ```julia-repl

--- a/src/Alphabet.jl
+++ b/src/Alphabet.jl
@@ -164,7 +164,7 @@ julia> A[-A["a"]]
 "c"
 ```
 """
-function Base.getindex(A::Alphabet{T}, p::Int) where T
+function Base.getindex(A::Alphabet{T}, p::Integer) where T
     if p > 0
         return A.alphabet[p]
     elseif p < 0 && A.inversions[-p] > 0

--- a/src/Alphabet.jl
+++ b/src/Alphabet.jl
@@ -130,7 +130,7 @@ julia> getindexbyelement(A, "c")
 3
 ```
 """
-function getindexbyelement(A::Alphabet{T}, x::T) where T
+function getindexbysymbol(A::Alphabet{T}, x::T) where T
     if (index = findfirst(symbol -> symbol == x, A.alphabet)) == nothing
         throw(DomainError("Element '$(x)' not found in the alphabet"))
     end
@@ -157,7 +157,7 @@ julia> A["c"]
 3
 ```
 """
-Base.getindex(A::Alphabet{T}, x::T) where T = getindexbyelement(A, x)
+Base.getindex(A::Alphabet{T}, x::T) where T = getindexbysymbol(A, x)
 
 
 """


### PR DESCRIPTION
This is a small correction of the previous pull request changes. It does not influence anything, but I wanted the types to be consistent.

**Edit.** I have extended this pull request by support for alphabets of integers. Previously, we had problems with the `getindex` function (one could not find a symbol in the alphabet of integers). Now, there is a lower-level function `getindexbysymbol` that explicitly finds a symbol, whatever type it is (including `Integer`).