### PR TITLE
Working kbs1, lenlexordering and minor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+.DS_Store

--- a/src/KnuthBendix.jl
+++ b/src/KnuthBendix.jl
@@ -2,5 +2,8 @@ module KnuthBendix
 
 include("words.jl")
 include("alphabets.jl")
+include("orderings.jl")
+include("rewriting.jl")
+include("kbs1.jl")
 
 end

--- a/src/kbs1.jl
+++ b/src/kbs1.jl
@@ -1,10 +1,10 @@
 """
-    test1!(u::Word, v::Word, rs::RewritingSystem, o::Ordering)
+    test1!(rs::RewritingSystem, u::Word, v::Word, o::Ordering)
 Adds a rule to a rewriting system (if necessary) that insures that there is
 a word derivable form two given words using the rules in rewriting system.
 See [Sims, p. 69].
 """
-function test1!(u::Word, v::Word, rs::RewritingSystem, o::Ordering)
+function test1!(rs::RewritingSystem, u::Word, v::Word, o::Ordering)
     a = rewrite_from_left(u, rs)
     b = rewrite_from_left(v, rs)
     if a != b
@@ -13,18 +13,20 @@ function test1!(u::Word, v::Word, rs::RewritingSystem, o::Ordering)
 end
 
 """
-    overlap1!(i::Integer, j::Integer, rs::RewritingSystem, o::Ordering)
+    overlap1!(rs::RewritingSystem, i::Integer, j::Integer, o::Ordering)
 Checks the overlaps of right sides of rules at position i and j in the rewriting
-system in which rule at i occurs at the beginning of the word. Adds new rules
-if failures of local confluence are found. See [Sims, p. 69].
+system in which rule at i occurs at the beginning of the word. When failures of
+local confluence are found, new rules are added. See [Sims, p. 69].
 """
-function overlap1!(i::Integer, j::Integer, rs::RewritingSystem, o::Ordering)
-    for k in 1:length(rs[i].first)
-        a = Word(rs[i].first[1:end-k])
-        b = Word(rs[i].first[end-k+1:end])
-        n = lcp(b, rs[j].first)
-        if isone(Word(b[n+1:end])) || isone(Word(rs[j].first[n+1:end]))
-            test1!(a * rs[j].second * Word(b[n+1:end]), rs[i].second * Word(rs[j].first[n+1:end]), rs, o)
+function overlap1!(rs::RewritingSystem,i::Integer, j::Integer,  o::Ordering)
+    lhs_i, rhs_i = rules(rs)[i]
+    lhs_j, rhs_j = rules(rs)[j]
+    for k in 1:length(lhs_i)
+        a = Word(lhs_i[1:end-k])
+        b = Word(lhs_i[end-k+1:end])
+        n = lcp(b, lhs_j)
+        if isone(Word(b[n+1:end])) || isone(Word(lhs_j[n+1:end]))
+            test1!(rs, a * rhs_j * Word(b[n+1:end]), rhs_i * Word(lhs_j[n+1:end]), o)
         end
     end
 end
@@ -36,47 +38,47 @@ proper subwords are irreducible with respect to this rewriting system.
 """
 function getirrsubsys(rs::RewritingSystem)
     rsides = []
-    for rule in rs
+    for (lhs, rhs) in rules(rs)
         ok = true
-        n = length(rule.first)
+        n = length(lhs)
         if n > 2
             for j in 2:(n-1)
-                w = Word(rule.first[1:j])
+                w = Word(lhs[1:j])
                 rw = rewrite_from_left(w, rs)
                 (w == rw) || (ok=false; break)
             end
             for i in 2:(n-1)
                 ok || break
                 for j in (i+1):n
-                    w = Word(rule.first[i:j])
+                    w = Word(lhs[i:j])
                     rw = rewrite_from_left(w, rs)
                     (w == rw) || (ok=false; break)
                 end
             end
         end
-        ok && push!(rsides, rule.first)
+        ok && push!(rsides, lhs)
     end
     return rsides
 end
 
 """
-    kbs1(rs::RewritingSystem, o::Ordering)
+    knuthbendix1(rs::RewritingSystem, o::Ordering)
 Implements a Knuth-Bendix algorithm that yields reduced, confluent rewriting
 system. See [Sims, p.68].
 
 Warning: termination may not occur.
 """
-function kbs1(rs::RewritingSystem, o::Ordering)
+function knuthbendix1(rs::RewritingSystem, o::Ordering)
     i = 1
     ss = zero(rs)
 
-    for rule in rs
-        test1!(rule.first, rule.second, ss, o)
+    for (rhs, lhs) in rules(rs)
+        test1!(ss, lhs, rhs, o)
     end
     while i ≤ length(ss)
         for j in 1:i
-            overlap1!(i,j, ss, o)
-            j<i && overlap1!(j,i, ss, o)
+            overlap1!(ss, i,j, o)
+            j<i && overlap1!(ss, j,i, o)
         end
         i += 1
     end

--- a/src/kbs1.jl
+++ b/src/kbs1.jl
@@ -4,7 +4,7 @@ Adds a rule to a rewriting system (if necessary) that insures that there is
 a word derivable form two given words using the rules in rewriting system.
 See [Sims, p. 69].
 """
-function test1!(rs::RewritingSystem, u::Word, v::Word, o::Ordering)
+function test1!(rs::RewritingSystem{W,O}, u::W, v::W, o::Ordering = ordering(rs))  where {W<:AbstractWord, O<:Ordering}
     a = rewrite_from_left(u, rs)
     b = rewrite_from_left(v, rs)
     if a != b
@@ -18,15 +18,15 @@ Checks the overlaps of right sides of rules at position i and j in the rewriting
 system in which rule at i occurs at the beginning of the overlap. When failures
 of local confluence are found, new rules are added. See [Sims, p. 69].
 """
-function overlap1!(rs::RewritingSystem,i::Integer, j::Integer,  o::Ordering)
+function overlap1!(rs::RewritingSystem{W,O},i::Integer, j::Integer,  o::Ordering = ordering(rs)) where {W<:AbstractWord, O<:Ordering}
     lhs_i, rhs_i = rules(rs)[i]
     lhs_j, rhs_j = rules(rs)[j]
     for k in 1:length(lhs_i)
-        a = Word(lhs_i[1:end-k])
-        b = Word(lhs_i[end-k+1:end])
+        a = W(lhs_i[1:end-k])
+        b = W(lhs_i[end-k+1:end])
         n = longestcommonprefix(b, lhs_j)
-        if isone(Word(b[n+1:end])) || isone(Word(lhs_j[n+1:end]))
-            test1!(rs, a * rhs_j * Word(b[n+1:end]), rhs_i * Word(lhs_j[n+1:end]), o)
+        if isone(W(b[n+1:end])) || isone(W(lhs_j[n+1:end]))
+            test1!(rs, a * rhs_j * W(b[n+1:end]), rhs_i * W(lhs_j[n+1:end]), o)
         end
     end
 end
@@ -36,21 +36,21 @@ end
 Returns a list of right sides of rules from rewriting system of which all the
 proper subwords are irreducible with respect to this rewriting system.
 """
-function getirrsubsys(rs::RewritingSystem)
+function getirrsubsys(rs::RewritingSystem{W,O})  where {W<:AbstractWord, O<:Ordering}
     rsides = []
     for (lhs, rhs) in rules(rs)
         ok = true
         n = length(lhs)
         if n > 2
             for j in 2:(n-1)
-                w = Word(lhs[1:j])
+                w = W(lhs[1:j])
                 rw = rewrite_from_left(w, rs)
                 (w == rw) || (ok=false; break)
             end
             for i in 2:(n-1)
                 ok || break
                 for j in (i+1):n
-                    w = Word(lhs[i:j])
+                    w = W(lhs[i:j])
                     rw = rewrite_from_left(w, rs)
                     (w == rw) || (ok=false; break)
                 end
@@ -68,7 +68,7 @@ system. See [Sims, p.68].
 
 Warning: termination may not occur.
 """
-function knuthbendix1(rs::RewritingSystem, o::Ordering)
+function knuthbendix1(rs::RewritingSystem, o::Ordering = ordering(rs))
     i = 1
     ss = zero(rs)
 

--- a/src/kbs1.jl
+++ b/src/kbs1.jl
@@ -15,8 +15,8 @@ end
 """
     overlap1!(rs::RewritingSystem, i::Integer, j::Integer, o::Ordering)
 Checks the overlaps of right sides of rules at position i and j in the rewriting
-system in which rule at i occurs at the beginning of the word. When failures of
-local confluence are found, new rules are added. See [Sims, p. 69].
+system in which rule at i occurs at the beginning of the overlap. When failures
+of local confluence are found, new rules are added. See [Sims, p. 69].
 """
 function overlap1!(rs::RewritingSystem,i::Integer, j::Integer,  o::Ordering)
     lhs_i, rhs_i = rules(rs)[i]
@@ -24,7 +24,7 @@ function overlap1!(rs::RewritingSystem,i::Integer, j::Integer,  o::Ordering)
     for k in 1:length(lhs_i)
         a = Word(lhs_i[1:end-k])
         b = Word(lhs_i[end-k+1:end])
-        n = lcp(b, lhs_j)
+        n = longestcommonprefix(b, lhs_j)
         if isone(Word(b[n+1:end])) || isone(Word(lhs_j[n+1:end]))
             test1!(rs, a * rhs_j * Word(b[n+1:end]), rhs_i * Word(lhs_j[n+1:end]), o)
         end

--- a/src/kbs1.jl
+++ b/src/kbs1.jl
@@ -1,0 +1,91 @@
+"""
+    test1!(u::Word, v::Word, rs::RewritingSystem, o::Ordering)
+Adds a rule to a rewriting system (if necessary) that insures that there is
+a word derivable form two given words using the rules in rewriting system.
+See [Sims, p. 69].
+"""
+function test1!(u::Word, v::Word, rs::RewritingSystem, o::Ordering)
+    a = rewrite_from_left(u, rs)
+    b = rewrite_from_left(v, rs)
+    if a != b
+        lt(o, a, b) ? push!(rs, b=>a) : push!(rs, a=>b)
+    end
+end
+
+"""
+    overlap1!(i::Integer, j::Integer, rs::RewritingSystem, o::Ordering)
+Checks the overlaps of right sides of rules at position i and j in the rewriting
+system in which rule at i occurs at the beginning of the word. Adds new rules
+if failures of local confluence are found. See [Sims, p. 69].
+"""
+function overlap1!(i::Integer, j::Integer, rs::RewritingSystem, o::Ordering)
+    for k in 1:length(rs[i].first)
+        a = Word(rs[i].first[1:end-k])
+        b = Word(rs[i].first[end-k+1:end])
+        n = lcp(b, rs[j].first)
+        if isone(Word(b[n+1:end])) || isone(Word(rs[j].first[n+1:end]))
+            test1!(a * rs[j].second * Word(b[n+1:end]), rs[i].second * Word(rs[j].first[n+1:end]), rs, o)
+        end
+    end
+end
+
+"""
+    getirrsubsys(rs::RewritingSystem)
+Returns a list of right sides of rules from rewriting system of which all the
+proper subwords are irreducible with respect to this rewriting system.
+"""
+function getirrsubsys(rs::RewritingSystem)
+    rsides = []
+    for rule in rs
+        ok = true
+        n = length(rule.first)
+        if n > 2
+            for j in 2:(n-1)
+                w = Word(rule.first[1:j])
+                rw = rewrite_from_left(w, rs)
+                (w == rw) || (ok=false; break)
+            end
+            for i in 2:(n-1)
+                ok || break
+                for j in (i+1):n
+                    w = Word(rule.first[i:j])
+                    rw = rewrite_from_left(w, rs)
+                    (w == rw) || (ok=false; break)
+                end
+            end
+        end
+        ok && push!(rsides, rule.first)
+    end
+    return rsides
+end
+
+"""
+    kbs1(rs::RewritingSystem, o::Ordering)
+Implements a Knuth-Bendix algorithm that yields reduced, confluent rewriting
+system. See [Sims, p.68].
+
+Warning: termination may not occur.
+"""
+function kbs1(rs::RewritingSystem, o::Ordering)
+    i = 1
+    ss = zero(rs)
+
+    for rule in rs
+        test1!(rule.first, rule.second, ss, o)
+    end
+    while i ≤ length(ss)
+        for j in 1:i
+            overlap1!(i,j, ss, o)
+            j<i && overlap1!(j,i, ss, o)
+        end
+        i += 1
+    end
+
+    p = getirrsubsys(ss)
+    ts = zero(rs)
+
+    for rside in p
+        push!(ts, rside=>rewrite_from_left(rside, ss))
+    end
+    return ts
+end

--- a/src/orderings.jl
+++ b/src/orderings.jl
@@ -1,0 +1,30 @@
+import Base.Order: lt, Ordering
+export LenLex
+
+"""
+    struct LenLex{T} <: Ordering
+
+Basic structure representing Length+Lexicographic (left-to-right) ordering of
+the words over given Alphabet. Lexicographing ordering of an Alphabet is
+implicitly specified inside Alphabet struct.
+"""
+struct LenLex{T} <: Ordering
+    A::Alphabet{T}
+end
+
+
+"""
+    lt(o::LenLex, p::T, q::T) where T<:Word{Integer}
+
+Return whether the first word is less then the other one in a given LenLex ordering.
+"""
+function lt(o::LenLex, p::T, q::T) where T<:AbstractWord{<:Integer}
+    if length(p) == length(q)
+        for (a, b) in zip(p,q)
+            a == b || return isless(a, b)  # comparing only on positive pointer values
+        end
+        return false
+    else
+        return isless(length(p), length(q))
+    end
+end

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -1,0 +1,82 @@
+"""
+    AbstractRewritingSystem{T} <: AbstractVector{T}
+Abstract type representing words over an Alphabet.
+
+`AbstractRewritingSystem` as such has its meaning only in the contex of an Alphabet.
+The subtypes of `AbstractRewritingSystem{T}` need to implement the following
+methods which constitute `AbstractRewritingSystem` interface:
+ * `Base.push!`/`Base.pushfirst!`: appending a single rule at the end/beginning
+ * `Base.append!`/`Base.prepend!`: appending a another system at the end/beginning,
+ * `Base.insert!`: inserting a single rule at a given place
+ * `Base.delateat!`: delating rules at given positions
+ * `Base.empty!`: delating all the rules
+ * full iteration protocol for `AbstractArray`s, returning pairs of Words (rules)
+ * `length` the length of word as written in the alphabet.
+"""
+
+abstract type AbstractRewritingSystem{T} <: AbstractVector{T} end
+
+"""
+    RewritingSystem{T} <: AbstractRewritingSystem{T}
+RewritingSystem written as a list of pairs of Words (left side => right side)
+"""
+struct RewritingSystem{T} <: AbstractRewritingSystem{T}
+    rwrules::Vector{T}
+end
+
+Base.:(==)(s::RewritingSystem, r::RewritingSystem) = s.rwrules == r.rwrules
+Base.hash(s::RewritingSystem, h::UInt) =
+    foldl((h, x) -> hash(x, h), s.rwrules, init = hash(0x905098c1dcf219bc, h))
+# the init value is simply hash(RewritingSystem)
+
+Base.zero(s::RewritingSystem{T}) where T = RewritingSystem{T}(Pair{T,T}[])
+Base.iszero(s::RewritingSystem) = isempty(s.rwrules)
+
+Base.push!(s::RewritingSystem, r::Pair{T,T}) where {T<:AbstractWord} = (push!(s.rwrules, r); s)
+Base.pushfirst!(s::RewritingSystem, r::Pair{T,T}) where {T<:AbstractWord} = (pushfirst!(s.rwrules, r); s)
+
+Base.append!(s::RewritingSystem, v::RewritingSystem) = (append!(s.rwrules, v.rwrules); s)
+Base.prepend!(s::RewritingSystem, v::RewritingSystem) = (prepend!(s.rwrules, v.rwrules); s)
+
+Base.insert!(s::RewritingSystem, i::Integer, r::Pair{T,T}) where {T<:AbstractWord} = (insert!(s.rwrules, i, r); s)
+Base.deleteat!(s::RewritingSystem, i::Integer) = (deleteat!(s.rwrules, i); s)
+Base.deleteat!(s::RewritingSystem, inds) = (deleteat!(s.rwrules, inds); s)
+Base.empty!(s::RewritingSystem) = (empty!(s.rwrules); s)
+
+Base.iterate(s::RewritingSystem) = iterate(s.rwrules)
+Base.iterate(s::RewritingSystem, state) = iterate(s.rwrules, state)
+Base.size(s::RewritingSystem) = size(s.rwrules)
+
+Base.@propagate_inbounds function Base.getindex(s::RewritingSystem, n::Integer)
+    @boundscheck checkbounds(s, n)
+    return @inbounds s.rwrules[n]
+end
+
+Base.@propagate_inbounds function Base.setindex!(s::RewritingSystem, v::Pair{T,T}, n::Integer) where {T<:AbstractWord}
+    @boundscheck checkbounds(s, n)
+    return @inbounds s.rwrules[n] = v
+end
+
+"""
+    rewrite_from_left(u::Word, rs::RewritingSystem)
+Rewrites a word from left using rules from a given RewritingSystem. See [Sims, p.66]
+"""
+function rewrite_from_left(u::Word, rs::RewritingSystem)
+    iszero(rs) && return u
+    v = one(u)
+    w = copy(u)
+    while !isone(w)
+        v *= Word(popfirst!(w))
+        for rule in rs
+            lenr = length(rule.first)
+            lenv = length(v)
+            if lenr ≤ lenv
+                if rule.first == Word(v[end-lenr+1:end])
+                    w = rule.second * w
+                    v = Word(v[1:end-lenr])
+                end
+            end
+        end
+    end
+    return v
+end

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -46,6 +46,9 @@ Base.empty!(s::RewritingSystem) = (empty!(s.rwrules); s)
 Base.iterate(s::RewritingSystem) = iterate(s.rwrules)
 Base.iterate(s::RewritingSystem, state) = iterate(s.rwrules, state)
 Base.size(s::RewritingSystem) = size(s.rwrules)
+Base.length(s::RewritingSystem) = length(s.rwrules)
+
+rules(s::RewritingSystem) = s.rwrules
 
 Base.@propagate_inbounds function Base.getindex(s::RewritingSystem, n::Integer)
     @boundscheck checkbounds(s, n)
@@ -66,14 +69,14 @@ function rewrite_from_left(u::Word, rs::RewritingSystem)
     v = one(u)
     w = copy(u)
     while !isone(w)
-        v *= Word(popfirst!(w))
-        for rule in rs
-            lenr = length(rule.first)
+        push!(v, popfirst!(w))
+        for (lhs, rhs) in rules(rs)
+            lenl = length(lhs)
             lenv = length(v)
-            if lenr ≤ lenv
-                if rule.first == Word(v[end-lenr+1:end])
-                    w = rule.second * w
-                    v = Word(v[1:end-lenr])
+            if lenl ≤ lenv
+                if lhs == Word(v[end-lenl+1:end])
+                    prepend!(w, rhs)
+                    v = Word(v[1:end-lenl])
                 end
             end
         end

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -1,9 +1,9 @@
 """
-    AbstractRewritingSystem{T}
+    AbstractRewritingSystem{W,O}
 Abstract type representing rewriting system.
 
 `AbstractRewritingSystem` as such has its meaning only in the contex of an Alphabet.
-The subtypes of `AbstractRewritingSystem{T}` need to implement the following
+The subtypes of `AbstractRewritingSystem{W,O}` need to implement the following
 methods which constitute `AbstractRewritingSystem` interface:
  * `Base.push!`/`Base.pushfirst!`: appending a single rule at the end/beginning
  * `Base.append!`/`Base.prepend!`: appending a another system at the end/beginning,
@@ -12,33 +12,35 @@ methods which constitute `AbstractRewritingSystem` interface:
  * `Base.empty!`: delating all the rules
  * `length`: the number of rules (not necessarily unique) stored inside the system
 """
-abstract type AbstractRewritingSystem{T} end
+abstract type AbstractRewritingSystem{W, O} end
 
 """
-    RewritingSystem{T} <: AbstractRewritingSystem{T}
-RewritingSystem written as a list of pairs of Words (left side => right side)
+    RewritingSystem{W<:AbstractWord, O<:Ordering} <: AbstractRewritingSystem{T}
+RewritingSystem written as a list of pairs of `Word`s together with the ordering
 """
-struct RewritingSystem{T} <: AbstractRewritingSystem{T}
-    rwrules::Vector{T}
+struct RewritingSystem{W<:AbstractWord, O<:Ordering} <: AbstractRewritingSystem{W, O}
+    rwrules::Vector{Pair{W,W}}
+    order::O
 end
 
 rules(s::RewritingSystem) = s.rwrules
+ordering(s::RewritingSystem) = s.order
 
-Base.:(==)(s::RewritingSystem, r::RewritingSystem) = rules(s) == rules(r)
+Base.:(==)(s::RewritingSystem, r::RewritingSystem) = (rules(s) == rules(r) && ordering(s) == ordering(r))
 Base.hash(s::RewritingSystem, h::UInt) =
-    foldl((h, x) -> hash(x, h), s.rwrules, init = hash(0x905098c1dcf219bc, h))
+    foldl((h, x) -> hash(x, h), s.rwrules, init = hash(s.order, hash(0x905098c1dcf219bc, h)))
 # the init value is simply hash(RewritingSystem)
 
-Base.zero(s::RewritingSystem{T}) where T = RewritingSystem{T}(Pair{T,T}[])
+Base.zero(s::RewritingSystem{W,O}) where {W,O} = RewritingSystem{W,O}(Pair{W,W}[], ordering(s))
 Base.iszero(s::RewritingSystem) = isempty(rules(s))
 
-Base.push!(s::RewritingSystem, r::Pair{T,T}) where {T<:AbstractWord} = (push!(rules(s), r); s)
-Base.pushfirst!(s::RewritingSystem, r::Pair{T,T}) where {T<:AbstractWord} = (pushfirst!(rules(s), r); s)
+Base.push!(s::RewritingSystem{W,O}, r::Pair{W,W}) where {W<:AbstractWord, O<:Ordering} = (push!(rules(s), r); s)
+Base.pushfirst!(s::RewritingSystem{W,O}, r::Pair{W,W}) where {W<:AbstractWord, O<:Ordering} = (pushfirst!(rules(s), r); s)
 
 Base.append!(s::RewritingSystem, v::RewritingSystem) = (append!(rules(s), rules(v)); s)
 Base.prepend!(s::RewritingSystem, v::RewritingSystem) = (prepend!(rules(s), rules(v)); s)
 
-Base.insert!(s::RewritingSystem, i::Integer, r::Pair{T,T}) where {T<:AbstractWord} = (insert!(rules(s), i, r); s)
+Base.insert!(s::RewritingSystem{W,O}, i::Integer, r::Pair{W,W}) where {W<:AbstractWord, O<:Ordering} = (insert!(rules(s), i, r); s)
 Base.deleteat!(s::RewritingSystem, i::Integer) = (deleteat!(rules(s), i); s)
 Base.deleteat!(s::RewritingSystem, inds) = (deleteat!(rules(s), inds); s)
 Base.empty!(s::RewritingSystem) = (empty!(rules(s)); s)
@@ -47,10 +49,10 @@ Base.length(s::RewritingSystem) = length(rules(s))
 
 
 """
-    rewrite_from_left(u::Word, rs::RewritingSystem)
+    rewrite_from_left(u::W, rs::RewritingSystem)
 Rewrites a word from left using rules from a given RewritingSystem. See [Sims, p.66]
 """
-function rewrite_from_left(u::Word, rs::RewritingSystem)
+function rewrite_from_left(u::W, rs::RewritingSystem{W,O}) where {W<:AbstractWord, O<:Ordering}
     iszero(rs) && return u
     v = one(u)
     w = copy(u)
@@ -60,9 +62,9 @@ function rewrite_from_left(u::Word, rs::RewritingSystem)
             lenl = length(lhs)
             lenv = length(v)
             if lenl ≤ lenv
-                if lhs == Word(v[end-lenl+1:end])
+                if lhs == W(v[end-lenl+1:end])
                     prepend!(w, rhs)
-                    v = Word(v[1:end-lenl])
+                    v = W(v[1:end-lenl])
                 end
             end
         end

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -1,6 +1,6 @@
 """
-    AbstractRewritingSystem{T} <: AbstractVector{T}
-Abstract type representing words over an Alphabet.
+    AbstractRewritingSystem{T}
+Abstract type representing rewriting system.
 
 `AbstractRewritingSystem` as such has its meaning only in the contex of an Alphabet.
 The subtypes of `AbstractRewritingSystem{T}` need to implement the following
@@ -10,11 +10,9 @@ methods which constitute `AbstractRewritingSystem` interface:
  * `Base.insert!`: inserting a single rule at a given place
  * `Base.delateat!`: delating rules at given positions
  * `Base.empty!`: delating all the rules
- * full iteration protocol for `AbstractRewritingSystem`s, returning pairs of Words (rules)
  * `length`: the number of rules (not necessarily unique) stored inside the system
 """
-
-abstract type AbstractRewritingSystem{T} <: AbstractVector{T} end
+abstract type AbstractRewritingSystem{T} end
 
 """
     RewritingSystem{T} <: AbstractRewritingSystem{T}
@@ -37,28 +35,16 @@ Base.iszero(s::RewritingSystem) = isempty(rules(s))
 Base.push!(s::RewritingSystem, r::Pair{T,T}) where {T<:AbstractWord} = (push!(rules(s), r); s)
 Base.pushfirst!(s::RewritingSystem, r::Pair{T,T}) where {T<:AbstractWord} = (pushfirst!(rules(s), r); s)
 
-Base.append!(s::RewritingSystem, v::RewritingSystem) = (append!(rules(s), v.rwrules); s)
-Base.prepend!(s::RewritingSystem, v::RewritingSystem) = (prepend!(rules(s), v.rwrules); s)
+Base.append!(s::RewritingSystem, v::RewritingSystem) = (append!(rules(s), rules(v)); s)
+Base.prepend!(s::RewritingSystem, v::RewritingSystem) = (prepend!(rules(s), rules(v)); s)
 
 Base.insert!(s::RewritingSystem, i::Integer, r::Pair{T,T}) where {T<:AbstractWord} = (insert!(rules(s), i, r); s)
 Base.deleteat!(s::RewritingSystem, i::Integer) = (deleteat!(rules(s), i); s)
 Base.deleteat!(s::RewritingSystem, inds) = (deleteat!(rules(s), inds); s)
 Base.empty!(s::RewritingSystem) = (empty!(rules(s)); s)
 
-Base.iterate(s::RewritingSystem) = iterate(s.rwrules)
-Base.iterate(s::RewritingSystem, state) = iterate(s.rwrules, state)
-Base.size(s::RewritingSystem) = size(rules(s))
 Base.length(s::RewritingSystem) = length(rules(s))
 
-Base.@propagate_inbounds function Base.getindex(s::RewritingSystem, n::Integer)
-    @boundscheck checkbounds(s, n)
-    return @inbounds s.rwrules[n]
-end
-
-Base.@propagate_inbounds function Base.setindex!(s::RewritingSystem, v::Pair{T,T}, n::Integer) where {T<:AbstractWord}
-    @boundscheck checkbounds(s, n)
-    return @inbounds s.rwrules[n] = v
-end
 
 """
     rewrite_from_left(u::Word, rs::RewritingSystem)

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -2,7 +2,6 @@
     AbstractRewritingSystem{W,O}
 Abstract type representing rewriting system.
 
-`AbstractRewritingSystem` as such has its meaning only in the contex of an Alphabet.
 The subtypes of `AbstractRewritingSystem{W,O}` need to implement the following
 methods which constitute `AbstractRewritingSystem` interface:
  * `Base.push!`/`Base.pushfirst!`: appending a single rule at the end/beginning

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -10,8 +10,8 @@ methods which constitute `AbstractRewritingSystem` interface:
  * `Base.insert!`: inserting a single rule at a given place
  * `Base.delateat!`: delating rules at given positions
  * `Base.empty!`: delating all the rules
- * full iteration protocol for `AbstractArray`s, returning pairs of Words (rules)
- * `length` the length of word as written in the alphabet.
+ * full iteration protocol for `AbstractRewritingSystem`s, returning pairs of Words (rules)
+ * `length`: the number of rules (not necessarily unique) stored inside the system
 """
 
 abstract type AbstractRewritingSystem{T} <: AbstractVector{T} end
@@ -24,31 +24,31 @@ struct RewritingSystem{T} <: AbstractRewritingSystem{T}
     rwrules::Vector{T}
 end
 
-Base.:(==)(s::RewritingSystem, r::RewritingSystem) = s.rwrules == r.rwrules
+rules(s::RewritingSystem) = s.rwrules
+
+Base.:(==)(s::RewritingSystem, r::RewritingSystem) = rules(s) == rules(r)
 Base.hash(s::RewritingSystem, h::UInt) =
     foldl((h, x) -> hash(x, h), s.rwrules, init = hash(0x905098c1dcf219bc, h))
 # the init value is simply hash(RewritingSystem)
 
 Base.zero(s::RewritingSystem{T}) where T = RewritingSystem{T}(Pair{T,T}[])
-Base.iszero(s::RewritingSystem) = isempty(s.rwrules)
+Base.iszero(s::RewritingSystem) = isempty(rules(s))
 
-Base.push!(s::RewritingSystem, r::Pair{T,T}) where {T<:AbstractWord} = (push!(s.rwrules, r); s)
-Base.pushfirst!(s::RewritingSystem, r::Pair{T,T}) where {T<:AbstractWord} = (pushfirst!(s.rwrules, r); s)
+Base.push!(s::RewritingSystem, r::Pair{T,T}) where {T<:AbstractWord} = (push!(rules(s), r); s)
+Base.pushfirst!(s::RewritingSystem, r::Pair{T,T}) where {T<:AbstractWord} = (pushfirst!(rules(s), r); s)
 
-Base.append!(s::RewritingSystem, v::RewritingSystem) = (append!(s.rwrules, v.rwrules); s)
-Base.prepend!(s::RewritingSystem, v::RewritingSystem) = (prepend!(s.rwrules, v.rwrules); s)
+Base.append!(s::RewritingSystem, v::RewritingSystem) = (append!(rules(s), v.rwrules); s)
+Base.prepend!(s::RewritingSystem, v::RewritingSystem) = (prepend!(rules(s), v.rwrules); s)
 
-Base.insert!(s::RewritingSystem, i::Integer, r::Pair{T,T}) where {T<:AbstractWord} = (insert!(s.rwrules, i, r); s)
-Base.deleteat!(s::RewritingSystem, i::Integer) = (deleteat!(s.rwrules, i); s)
-Base.deleteat!(s::RewritingSystem, inds) = (deleteat!(s.rwrules, inds); s)
-Base.empty!(s::RewritingSystem) = (empty!(s.rwrules); s)
+Base.insert!(s::RewritingSystem, i::Integer, r::Pair{T,T}) where {T<:AbstractWord} = (insert!(rules(s), i, r); s)
+Base.deleteat!(s::RewritingSystem, i::Integer) = (deleteat!(rules(s), i); s)
+Base.deleteat!(s::RewritingSystem, inds) = (deleteat!(rules(s), inds); s)
+Base.empty!(s::RewritingSystem) = (empty!(rules(s)); s)
 
 Base.iterate(s::RewritingSystem) = iterate(s.rwrules)
 Base.iterate(s::RewritingSystem, state) = iterate(s.rwrules, state)
-Base.size(s::RewritingSystem) = size(s.rwrules)
-Base.length(s::RewritingSystem) = length(s.rwrules)
-
-rules(s::RewritingSystem) = s.rwrules
+Base.size(s::RewritingSystem) = size(rules(s))
+Base.length(s::RewritingSystem) = length(rules(s))
 
 Base.@propagate_inbounds function Base.getindex(s::RewritingSystem, n::Integer)
     @boundscheck checkbounds(s, n)

--- a/src/words.jl
+++ b/src/words.jl
@@ -82,11 +82,11 @@ Base.@propagate_inbounds function Base.setindex!(w::Word, v::Integer, n::Integer
 end
 
 """
-    lcp(u::Word, v::Word)
+    longestcommonprefix(u::Word, v::Word)
 Returns the length of longest common prefix of two words (and simultaneously
 the index at which the prefix ends).
 """
-function lcp(u::Word, v::Word)
+function longestcommonprefix(u::Word, v::Word)
     n=0
     for (lu, lv) in zip(u,v)
         lu != lv && break

--- a/src/words.jl
+++ b/src/words.jl
@@ -88,10 +88,9 @@ the index at which the prefix ends).
 """
 function lcp(u::Word, v::Word)
     n=0
-    for i in zip(u,v)
-        if i[1] == i[2]
-            n += 1
-        end
+    for (lu, lv) in zip(u,v)
+        lu != lv && break
+        n += 1
     end
     return n
 end

--- a/src/words.jl
+++ b/src/words.jl
@@ -9,6 +9,7 @@ constitute `AbstractWord` interface:
  * `Base.hash`: simple uniqueness hashing function
  * `Base.one` the empty word (i.e. monoid identity element)
  * `Base.push!`/`Base.pushfirst!`: appending a single value at the end/beginning
+ * `Base.pop!`/`Base.popfirst!`: popping a single value from the end/beginning
  * `Base.append!`/`Base.prepend!`: appending a another word at the end/beginning,
  * `Base.:*` for words concatentation (monoid binary operation)
  * full iteration protocol for `AbstractArray`s, returning pointers to letters
@@ -40,6 +41,8 @@ struct Word{T} <: AbstractWord{T}
     end
 end
 
+Word(n::Integer) = Word([n])
+
 # setting the default type to Int16
 Word(x::Union{<:Vector{<:Integer},<:AbstractVector{<:Integer}}) = Word{UInt16}(x)
 
@@ -58,6 +61,9 @@ Base.prepend!(w::Word, v::Word) = (prepend!(w.ptrs, v.ptrs); w)
 Base.:*(w::Word{S}, v::Word{T}) where {S,T} =
     (TT = promote_type(S, T); Word{TT}(TT[w.ptrs; v.ptrs]))
 
+Base.pop!(w::Word) = (pop!(w.ptrs))
+Base.popfirst!(w::Word) = (popfirst!(w.ptrs))
+
 Base.iterate(w::Word) = iterate(w.ptrs)
 Base.iterate(w::Word, state) = iterate(w.ptrs, state)
 Base.size(w::Word) = size(w.ptrs)
@@ -73,4 +79,19 @@ Base.@propagate_inbounds function Base.setindex!(w::Word, v::Integer, n::Integer
     @boundscheck checkbounds(w, n)
     @assert v > 0 "All entries of a Word must be positive integers"
     return @inbounds w.ptrs[n] = v
+end
+
+"""
+    lcp(u::Word, v::Word)
+Returns the length of longest common prefix of two words (and simultaneously
+the index at which the prefix ends).
+"""
+function lcp(u::Word, v::Word)
+    n=0
+    for i in zip(u,v)
+        if i[1] == i[2]
+            n += 1
+        end
+    end
+    return n
 end

--- a/test/kbs1.jl
+++ b/test/kbs1.jl
@@ -1,0 +1,42 @@
+@testset "KBS1" begin
+
+    import KnuthBendix.Word
+
+    A = KnuthBendix.Alphabet(['a', 'e', 'b', 'p'])
+    KnuthBendix.set_inversion!(A, 'a', 'e')
+    KnuthBendix.set_inversion!(A, 'b', 'p')
+
+    a = Word([1,2])
+    b = Word([2,1])
+    c = Word([3,4])
+    d = Word([4,3])
+    ε = one(a)
+
+    ba = Word([3,1])
+    ab = Word([1,3])
+
+    be = Word([3,2])
+    eb = Word([2,3])
+
+    pa = Word([4,1])
+    ap = Word([1,4])
+
+    pe = Word([4,2])
+    ep = Word([2,4])
+
+    lenlexord = KnuthBendix.LenLex(A)
+    rs = KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab])
+
+    rsc = KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, be=>eb, pa=>ap, pe=>ep])
+
+    @test KnuthBendix.kbs1(rs, lenlexord) == rsc
+    @test KnuthBendix.getirrsubsys(rsc) == [a,b,c,d,ba,be,pa,pe]
+
+    KnuthBendix.overlap1!(5,1, rs, lenlexord)
+    @test rs == KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, Word([1,3,2])=>Word([3])])
+
+    KnuthBendix.test1!(Word([4,1,3]), Word(1), rs, lenlexord)
+    @test rs == KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, Word([1,3,2])=>Word([3]), Word([4,1,3])=>Word(1)])
+
+end
+

--- a/test/kbs1.jl
+++ b/test/kbs1.jl
@@ -25,18 +25,18 @@
     ep = Word([2,4])
 
     lenlexord = KnuthBendix.LenLex(A)
-    rs = KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab])
+    rs = KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab], lenlexord)
 
-    rsc = KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, be=>eb, pa=>ap, pe=>ep])
+    rsc = KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, be=>eb, pa=>ap, pe=>ep], lenlexord)
 
-    @test KnuthBendix.knuthbendix1(rs, lenlexord) == rsc
+    @test KnuthBendix.knuthbendix1(rs) == rsc
     @test KnuthBendix.getirrsubsys(rsc) == [a,b,c,d,ba,be,pa,pe]
 
-    KnuthBendix.overlap1!(rs, 5,1, lenlexord)
-    @test rs == KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, Word([1,3,2])=>Word([3])])
+    KnuthBendix.overlap1!(rs,5,1)
+    @test rs == KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, Word([1,3,2])=>Word([3])], lenlexord)
 
-    KnuthBendix.test1!(rs, Word([4,1,3]), Word(1), lenlexord)
-    @test rs == KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, Word([1,3,2])=>Word([3]), Word([4,1,3])=>Word(1)])
+    KnuthBendix.test1!(rs, Word([4,1,3]), Word(1))
+    @test rs == KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, Word([1,3,2])=>Word([3]), Word([4,1,3])=>Word(1)], lenlexord)
 
 end
 

--- a/test/kbs1.jl
+++ b/test/kbs1.jl
@@ -29,13 +29,13 @@
 
     rsc = KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, be=>eb, pa=>ap, pe=>ep])
 
-    @test KnuthBendix.kbs1(rs, lenlexord) == rsc
+    @test KnuthBendix.knuthbendix1(rs, lenlexord) == rsc
     @test KnuthBendix.getirrsubsys(rsc) == [a,b,c,d,ba,be,pa,pe]
 
-    KnuthBendix.overlap1!(5,1, rs, lenlexord)
+    KnuthBendix.overlap1!(rs, 5,1, lenlexord)
     @test rs == KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, Word([1,3,2])=>Word([3])])
 
-    KnuthBendix.test1!(Word([4,1,3]), Word(1), rs, lenlexord)
+    KnuthBendix.test1!(rs, Word([4,1,3]), Word(1), lenlexord)
     @test rs == KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, Word([1,3,2])=>Word([3]), Word([4,1,3])=>Word(1)])
 
 end

--- a/test/orderings.jl
+++ b/test/orderings.jl
@@ -1,0 +1,24 @@
+@testset "Orderings" begin
+
+    import KnuthBendix.Alphabet, KnuthBendix.set_inversion!, KnuthBendix.Word
+    import KnuthBendix.LenLex, Base.Order.lt
+
+    A = Alphabet(['a', 'b', 'c', 'd'])
+    set_inversion!(A, 'a', 'b')
+    set_inversion!(A, 'c', 'd')
+
+    lenlexord = LenLex(A)
+
+    @test lenlexord isa Base.Order.Ordering
+
+    u1 = Word([1,2])
+    u3 = Word([1,3])
+    u4 = Word([1,2,3])
+    u5 = Word([1,4,2])
+
+    @test lt(lenlexord, u1, u3) == true
+    @test lt(lenlexord, u3, u1) == false
+    @test lt(lenlexord, u3, u4) == true
+    @test lt(lenlexord, u4, u5) == true
+    @test lt(lenlexord, u5, u4) == false
+end

--- a/test/orderings.jl
+++ b/test/orderings.jl
@@ -21,4 +21,5 @@
     @test lt(lenlexord, u3, u4) == true
     @test lt(lenlexord, u4, u5) == true
     @test lt(lenlexord, u5, u4) == false
+    @test lt(lenlexord, u1, u1) == false
 end

--- a/test/rewriting.jl
+++ b/test/rewriting.jl
@@ -30,22 +30,18 @@
     @test hash(s, UInt(1)) != hash(s, UInt(0))
 
     @test push!(z, c=>ε) == RewritingSystem([c=>ε])
-    @test z[1] == (c=>ε)
+    @test KnuthBendix.rules(z)[1] == (c=>ε)
     @test z == RewritingSystem([c=>ε])
 
     @test pushfirst!(z, b=>ε) == RewritingSystem([b=>ε, c=>ε])
-    @test z[1] == (b=>ε)
+    @test KnuthBendix.rules(z)[1] == (b=>ε)
     @test z == RewritingSystem([b=>ε, c=>ε])
 
     @test append!(z, RewritingSystem([ba=>ab])) == RewritingSystem([b=>ε, c=>ε, ba=>ab])
     @test prepend!(z, RewritingSystem([a=>ε])) == RewritingSystem([a=>ε, b=>ε, c=>ε, ba=>ab])
 
-    @test collect(z) == [a=>ε, b=>ε, c=>ε, ba=>ab]
-    @test collect(z) isa Vector{Pair{Word{UInt16},Word{UInt16}}}
-    @test z[1] == (a=>ε)
+    @test KnuthBendix.rules(z)[1] == (a=>ε)
     @test length(z) == 4
-    @test_throws BoundsError s[-1]
-    @test_throws BoundsError s[7]
 
     @test KnuthBendix.rules(z) == [a=>ε, b=>ε, c=>ε, ba=>ab]
 

--- a/test/rewriting.jl
+++ b/test/rewriting.jl
@@ -1,0 +1,61 @@
+@testset "Rewriting" begin
+
+    import KnuthBendix.Word, KnuthBendix.RewritingSystem, KnuthBendix.Alphabet, KnuthBendix.set_inversion!
+
+    A = Alphabet{String}(["a", "e", "b", "p"])
+    set_inversion!(A, "a", "e")
+    set_inversion!(A, "b", "p")
+
+    a = Word([1,2])
+    b = Word([2,1])
+    c = Word([3,4])
+    d = Word([4,3])
+    ε = one(a)
+
+    ba = Word([3,1])
+    ab = Word([1,3])
+
+    s = RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab])
+    z = zero(s)
+
+    @test s isa KnuthBendix.AbstractRewritingSystem
+    @test s isa RewritingSystem
+
+    @test s !==  z
+    @test iszero(z)
+    @test !iszero(s)
+
+    @test hash(s) isa UInt
+    @test hash(s) !== hash(z)
+    @test hash(s, UInt(1)) != hash(s, UInt(0))
+
+    @test push!(z, c=>ε) == RewritingSystem([c=>ε])
+    @test z[1] == (c=>ε)
+    @test z == RewritingSystem([c=>ε])
+
+    @test pushfirst!(z, b=>ε) == RewritingSystem([b=>ε, c=>ε])
+    @test z[1] == (b=>ε)
+    @test z == RewritingSystem([b=>ε, c=>ε])
+
+    @test append!(z, RewritingSystem([ba=>ab])) == RewritingSystem([b=>ε, c=>ε, ba=>ab])
+    @test prepend!(z, RewritingSystem([a=>ε])) == RewritingSystem([a=>ε, b=>ε, c=>ε, ba=>ab])
+
+    @test collect(z) == [a=>ε, b=>ε, c=>ε, ba=>ab]
+    @test collect(z) isa Vector{Pair{Word{UInt16},Word{UInt16}}}
+    @test z[1] == (a=>ε)
+    @test length(z) == 4
+    @test_throws BoundsError s[-1]
+    @test_throws BoundsError s[7]
+
+    @test insert!(z, 4, d=>ε) == s
+    @test hash(s) == hash(z)
+    @test deleteat!(z, 5) == RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε])
+    @test deleteat!(z, 3:4) == RewritingSystem([a=>ε, b=>ε])
+
+    @test KnuthBendix.rewrite_from_left(a, s) == ε
+    @test KnuthBendix.rewrite_from_left(c, z) == c
+
+    @test empty!(z) == zero(s)
+    @test KnuthBendix.rewrite_from_left(c, z) == c
+
+end

--- a/test/rewriting.jl
+++ b/test/rewriting.jl
@@ -5,6 +5,7 @@
     A = Alphabet{String}(["a", "e", "b", "p"])
     set_inversion!(A, "a", "e")
     set_inversion!(A, "b", "p")
+    lenlexord = KnuthBendix.LenLex(A)
 
     a = Word([1,2])
     b = Word([2,1])
@@ -15,7 +16,7 @@
     ba = Word([3,1])
     ab = Word([1,3])
 
-    s = RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab])
+    s = RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab], lenlexord)
     z = zero(s)
 
     @test s isa KnuthBendix.AbstractRewritingSystem
@@ -29,16 +30,17 @@
     @test hash(s) !== hash(z)
     @test hash(s, UInt(1)) != hash(s, UInt(0))
 
-    @test push!(z, c=>ε) == RewritingSystem([c=>ε])
+    @test push!(z, c=>ε) == RewritingSystem([c=>ε], lenlexord)
     @test KnuthBendix.rules(z)[1] == (c=>ε)
-    @test z == RewritingSystem([c=>ε])
+    @test KnuthBendix.ordering(z) == lenlexord
+    @test z == RewritingSystem([c=>ε], lenlexord)
 
-    @test pushfirst!(z, b=>ε) == RewritingSystem([b=>ε, c=>ε])
+    @test pushfirst!(z, b=>ε) == RewritingSystem([b=>ε, c=>ε], lenlexord)
     @test KnuthBendix.rules(z)[1] == (b=>ε)
-    @test z == RewritingSystem([b=>ε, c=>ε])
+    @test z == RewritingSystem([b=>ε, c=>ε], lenlexord)
 
-    @test append!(z, RewritingSystem([ba=>ab])) == RewritingSystem([b=>ε, c=>ε, ba=>ab])
-    @test prepend!(z, RewritingSystem([a=>ε])) == RewritingSystem([a=>ε, b=>ε, c=>ε, ba=>ab])
+    @test append!(z, RewritingSystem([ba=>ab], lenlexord)) == RewritingSystem([b=>ε, c=>ε, ba=>ab], lenlexord)
+    @test prepend!(z, RewritingSystem([a=>ε], lenlexord)) == RewritingSystem([a=>ε, b=>ε, c=>ε, ba=>ab], lenlexord)
 
     @test KnuthBendix.rules(z)[1] == (a=>ε)
     @test length(z) == 4
@@ -47,8 +49,8 @@
 
     @test insert!(z, 4, d=>ε) == s
     @test hash(s) == hash(z)
-    @test deleteat!(z, 5) == RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε])
-    @test deleteat!(z, 3:4) == RewritingSystem([a=>ε, b=>ε])
+    @test deleteat!(z, 5) == RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε], lenlexord)
+    @test deleteat!(z, 3:4) == RewritingSystem([a=>ε, b=>ε], lenlexord)
 
     @test KnuthBendix.rewrite_from_left(a, s) == ε
     @test KnuthBendix.rewrite_from_left(c, z) == c

--- a/test/rewriting.jl
+++ b/test/rewriting.jl
@@ -47,6 +47,8 @@
     @test_throws BoundsError s[-1]
     @test_throws BoundsError s[7]
 
+    @test KnuthBendix.rules(z) == [a=>ε, b=>ε, c=>ε, ba=>ab]
+
     @test insert!(z, 4, d=>ε) == s
     @test hash(s) == hash(z)
     @test deleteat!(z, 5) == RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,7 @@ using Test
 @testset "KnuthBendix.jl" begin
    include("words.jl")
    include("alphabets.jl")
+   include("orderings.jl")
+   include("rewriting.jl")
+   include("kbs1.jl")
 end

--- a/test/words.jl
+++ b/test/words.jl
@@ -47,4 +47,17 @@
 
     @test Word([1, 2]) * Word([2, 3]) == Word([1, 2, 2, 3])
     @test Word([1, 2]) * W == Word([1, 2, 1, 2])
+
+    u1 = Word([1,2,3,4])
+    u2 = Word([1,2])
+    u3 = Word([4,1,2,3,4])
+
+    @test KnuthBendix.lcp(u1, u2) == 2
+    @test KnuthBendix.lcp(u1, u1) == 4
+    @test KnuthBendix.lcp(u3, u2) == 0
+
+    @test pop!(u2) == 2
+    @test u2 == Word(1)
+    @test popfirst!(u3) == 4
+    @test u3 == u1
 end

--- a/test/words.jl
+++ b/test/words.jl
@@ -52,9 +52,9 @@
     u2 = Word([1,2])
     u3 = Word([4,1,2,3,4])
 
-    @test KnuthBendix.lcp(u1, u2) == 2
-    @test KnuthBendix.lcp(u1, u1) == 4
-    @test KnuthBendix.lcp(u3, u2) == 0
+    @test KnuthBendix.longestcommonprefix(u1, u2) == 2
+    @test KnuthBendix.longestcommonprefix(u1, u1) == 4
+    @test KnuthBendix.longestcommonprefix(u3, u2) == 0
 
     @test pop!(u2) == 2
     @test u2 == Word(1)


### PR DESCRIPTION
Working `kbs1` together with `LenLexOrdering` that now takes into account that words consist only of positive pointers. Also added some additional methods for `Word`. 

I checked with the examples from Sims: reproduced tables 2.5.1, 2.5.3, 2.5.4 (in the last one there is an error in the book: rule 13 shall not be in the table) and also reproduced the sets of final systems.

Note: I did not try to optimise the code (there was no point for `kbs1`), it is basically 1-1 what was in the book.

Remark: I did `AbstractRewritingSystem` and `RewritingSystem` similarly to the way `Word` was done. I am not sure it is good though.

To consider for later: right now when we iterate over `Word` we obtain Integers. If we subset `Word` via iterator we obtain a vector. Maybe it is sensible to always obtain `Word` via that protocol, i.e. `Word([1,2,3])[2] = Word([2])` and `Word([1,2,3])[2:3] = Word([2,3])`. It would make the code for `kbs1` clearer (shall I open an issue to discuss it separately? This is not something important and maybe later it will become more evident in which way this should be solved).