### PR TITLE
Enh/rewrite interface

### DIFF
--- a/src/abstract_words.jl
+++ b/src/abstract_words.jl
@@ -30,11 +30,10 @@ performance reasons:
 
 abstract type AbstractWord{T<:Integer} <: AbstractVector{T} end
 
-# hash(AbstractWord) == 0xc611974db9cee4d8
-Base.hash(w::W, h::UInt) where W<:AbstractWord =
-    foldl((h, x) -> hash(x, h), w, init = hash(0xc611974db9cee4d8, h))
+Base.hash(w::AbstractWord, h::UInt) =
+    foldl((h, x) -> hash(x, h), w, init = hash(AbstractWord, h))
 @inline Base.:(==)(w::AbstractWord, v::AbstractWord) =
-    length(w) == length(v) && all(@inbounds w[i] == v[i] for i in eachindex(w))
+    length(w) == length(v) && all(@inbounds w[i] == v[i] for i in 1:length(w))
 
 Base.size(w::AbstractWord) = (length(w),)
 

--- a/src/alphabets.jl
+++ b/src/alphabets.jl
@@ -238,3 +238,6 @@ function Base.inv(w::AbstractWord, A::Alphabet)
     end
     return res
 end
+
+string_repr(w::AbstractWord, A::Alphabet) =
+    (isone(w) ? "(empty word)" : join((A[i] for i in w), "*"))

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -128,12 +128,13 @@ struct Automaton{T, N, W<:AbstractWord{T}} <: AbstractAutomaton{T, N, W}
     states::Vector{State{T, N, W}}
     abt::Alphabet
     uniquenoedge::State{T, N, W}
+    _past_states::Vector{State{T, N, W}}
 end
 
 # Default type is set to UInt16
 function Automaton(abt::Alphabet)
     uniquenoedge = State{UInt16, length(abt), Word{UInt16}}()
-    Automaton{UInt16, length(abt), Word{UInt16}}([State(Word{UInt16}(), uniquenoedge)], abt, uniquenoedge)
+    Automaton{UInt16, length(abt), Word{UInt16}}([State(Word{UInt16}(), uniquenoedge)], abt, uniquenoedge, State{UInt16, length(abt), Word{UInt16}}[])
 end
 
 alphabet(a::Automaton) = a.abt
@@ -304,7 +305,8 @@ Rewrites word `w` from left using index automaton `a` and appends the result
 to `v`. For standard rewriting `v` should be empty.
 """
 function rewrite_from_left!(v::AbstractWord, w::AbstractWord, a::Automaton)
-    past_states = similar(states(a), length(w))
+    past_states = a._past_states
+    resize!(past_states, length(w))
     state = initialstate(a)
     past_states[1] = state
     initial_length = length(v)

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -240,19 +240,17 @@ end
 walk(a::Automaton{T, N, W}, w::W) where {T, N, W} = walk(a, w, 1)
 
 
-function Base.show(io::IO, a::Automaton)
+function Base.show(io::IO, a::AbstractAutomaton)
     println(io, "Automaton with $(length(states(a))) states")
-    abt = a.abt
     for (i, state) in enumerate(states(a))
-        println(io, " $i. Edges leaving state (", constructword(name(state), abt), "):")
+        println(io, " $i. Edges leaving state (", string_repr(name(state), alphabet(a)), "):")
 
         for (i, tostate) in enumerate(outedges(state))
-            !isnoedge(tostate) && println(io, "   ", " - with label ", abt[i], " to state (", constructword(name(tostate), abt), ")")
+            !isnoedge(tostate) && println(io,
+                "   ", " - with label ", alphabet(a)[i], " to state (", string_repr(name(tostate), alphabet(a)), ")")
         end
     end
 end
-constructword(W::AbstractWord, A::Alphabet) = isone(W) ? "ε" : join(A[w] for w in W)
-
 
 ###########################################
 # Ad index automata

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -255,7 +255,7 @@ end
     makeindexautomaton(rws::RewritingSystem, abt::Alphabet)
 Creates index automaton corresponding to a given rewriting system.
 """
-function makeindexautomaton(rws::RewritingSystem, abt::Alphabet)
+function makeindexautomaton(rws::RewritingSystem, abt::Alphabet=alphabet(ordering(rws)))
     Σᵢ = Int[0]
     a = Automaton(abt)
     # Determining simple paths

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -219,25 +219,22 @@ Base.@propagate_inbounds function Base.deleteat!(a::Automaton, idx::Integer)
 end
 
 """
-    walk(a::Automaton{T, N, W}, sig::W, first::Integer) where {T, N, W}
-Travels through index automaton according to the path given by the signature
-starting from the state at position `first`. Returns a tuple (idx, state) where
-idx is the last index of the letter from signature used to travel through automaton
-and state is the resulting state. Note that `idx` ≂̸ `length(sig)` that there is no
-path corresponding to the full signature.
+    walk(a::AbstractAutomaton, sig::AbstractWord[, state=first(states(a))])
+Walk through index automaton according to the path given by the signature `sig`,
+starting from `state`. Returns a tuple `(idx, state)` where `idx` is the last
+index of the letter from signature used to walk through automaton and `state` is
+the resulting state.
+
+Note that if `idx ≠ length(sig)` there is no path corresponding to the full signature.
 """
-function walk(a::Automaton{T, N, W}, sig::W, first::Integer) where {T, N, W}
-    σ = states(a)[first]
-    i = 0
-    for (idx, k) in enumerate(sig)
-        next = outedges(σ)[k]
-        isnoedge(next) ? break : (i, σ) = (idx, next)
+function walk(a::AbstractAutomaton, sig::AbstractWord, state=first(states(a)))
+    idx = 0
+    for (i, k) in enumerate(sig)
+        next = outedges(state)[k]
+        isnoedge(next) ? break : (idx, state) = (i, next)
     end
-    return (i, σ)
+    return (idx, state)
 end
-
-walk(a::Automaton{T, N, W}, w::W) where {T, N, W} = walk(a, w, 1)
-
 
 function Base.show(io::IO, a::AbstractAutomaton)
     println(io, "Automaton with $(length(states(a))) states")

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -148,11 +148,10 @@ Base.push!(a::Automaton{T, N, W}, name::W) where {T, N, W} = push!(states(a), St
     replace(k::NTuple{N, T}, val::T, idx::Integer) where {N, T}
 Returns a copy of `NTuple` `k` with value at index `idx` changed to `val`.
 """
-Base.@propagate_inbounds function replace(k::NTuple{N, T}, val, idx::Integer) where {N, T}
+Base.@propagate_inbounds function replace(k::NTuple{N, T}, val::T, idx::Integer) where {N, T}
     @boundscheck 1 ≤ idx ≤ N || throw(BoundsError(k, idx))
-    return ntuple( i->i==idx ? val : k[i], N)
+    return @inbounds ntuple( i -> i==idx ? val : k[i], Val(N))
 end
-
 
 """
     updateoutedges!(s::State, to::State, label::Integer)

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -100,7 +100,6 @@ function Base.show(io::IO, s::State)
     end
 end
 
-
 ###########################################
 # Automata
 

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -61,7 +61,7 @@ end
 
 name(s::State) = s.name
 isterminal(s::State) = s.terminal
-rightrule(s::State) = isterminal(s) ? s.rrule : nothing
+rightrule(s::State) = s.rrule
 inedges(s::State) = s.ined
 outedges(s::State) = s.outed
 isnoedge(s::State) = s.representsnoedge

--- a/src/bufferwords.jl
+++ b/src/bufferwords.jl
@@ -68,9 +68,8 @@ function Base.push!(bw::BufferWord, k::Integer)
     if internal_length(bw) == bw.ridx
         _growatend!(bw, max(length(bw), 16))
     end
-    @assert bw.lidx ≤ bw.ridx+1 ≤ internal_length(bw)
     bw.ridx += 1
-    bw[end] = k
+    @inbounds bw[end] = k
     return bw
 end
 
@@ -78,22 +77,20 @@ function Base.pushfirst!(bw::BufferWord, k::Integer)
     if bw.lidx ≤ firstindex(bw.storage)
         _growatbeg!(bw, max(length(bw), 16))
     end
-    @assert firstindex(bw.storage) ≤ bw.lidx-1 ≤ bw.ridx
     bw.lidx -= 1
-    bw[1] = k
+    @inbounds bw[1] = k
     return bw
 end
 
 function Base.pop!(bw::BufferWord)
     @assert !isempty(bw)
-    val = bw[end]
+    @inbounds val = bw[end]
     bw.ridx -= 1
     return val
 end
 
 function Base.popfirst!(bw::BufferWord)
-    @assert !isempty(bw)
-    val = bw[1]
+    @inbounds val = bw[1]
     bw.lidx +=1
     return val
 end
@@ -106,7 +103,6 @@ function Base.prepend!(bw::BufferWord, w::AbstractVector)
     if (free_space - lw) ≤ 0
         _growatbeg!(bw, lw)
     end
-    @assert bw.lidx > lw
 
     @inbounds for i in 1:lw
         bw.storage[bw.lidx-lw+i-1] = w[i]
@@ -124,7 +120,6 @@ function Base.append!(bw::BufferWord, w::AbstractVector)
     if (free_space - lw) ≤ 0
         _growatend!(bw, lw)
     end
-    @assert internal_length(bw) - bw.ridx ≥ lw
 
     @inbounds for i in 1:lw
         bw.storage[bw.ridx+i] = w[i]
@@ -158,10 +153,10 @@ function Base.:*(bw::BufferWord, bv::BufferWord)
         bv.ridx)
     res.lidx = bw.lidx
     res.ridx = res.lidx+length(bw)+length(bv)-1
-    for i in 1:length(bw)
+    @inbounds for i in 1:length(bw)
         res[i] = bw[i]
     end
-    for i in 1:length(bv)
+    @inbounds for i in 1:length(bv)
         res[length(bw)+i] = bv[i]
     end
     return res

--- a/src/orderings.jl
+++ b/src/orderings.jl
@@ -32,4 +32,4 @@ function lt(o::LenLex, p::T, q::T) where T<:AbstractWord{<:Integer}
     end
 end
 
-Base.getindex(o::Ordering, W::AbstractWord) = [alphabet(o)[w] for w in W]
+string_repr(W::AbstractWord, o::Ordering) = string_repr(W, alphabet(o))

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -118,10 +118,9 @@ end
 
 function Base.show(io::IO, rws::RewritingSystem)
     println(io, "Rewriting System with $(length(rules(rws))) rules ordered by $(ordering(rws)):")
-    O = ordering(rws)
     for (i, (lhs, rhs)) in enumerate(rules(rws))
-        lhs_str = join(O[lhs], "*")
-        rhs_str = isone(rhs) ? "(empty word)" : join(O[rhs], "*")
+        lhs_str = string_repr(lhs, ordering(rws))
+        rhs_str = string_repr(rhs, ordering(rws))
         act = isactive(rws, i) ? "✓" : " "
         println(io, lpad("$i", 4, " "), " $act ", lhs_str, "\t → \t", rhs_str)
     end

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -1,4 +1,44 @@
 """
+    rewrite_from_left(u::AbstractWord, rewriting)
+Rewrites a word from left using `rewriting` object. The object must implement
+`rewrite_from_left!(v::AbstractWord, w::AbstractWord, rewriting)` to succesfully rewrite `u`.
+"""
+function rewrite_from_left(u::W, rewriting) where {W<:AbstractWord}
+    isempty(rewriting) && return u
+    T = eltype(u)
+    v = BufferWord{T}(0, length(u))
+    w = BufferWord{T}(u, 0, 0)
+    v = rewrite_from_left!(v, w, rewriting)
+    return W(v)
+end
+
+"""
+    rewrite_from_left!(v::AbstractWord, w::AbstractWord, ::Any)
+Trivial rewrite: word `w` is simply appended to `v`.
+"""
+rewrite_from_left!(v::AbstractWord, w::AbstractWord, ::Any) = append!(v, w)
+
+"""
+    rewrite_from_left!(v::AbstractWord, w::AbstractWord, rule::Pair{<:AbstractWord, <:AbstractWord})
+Rewrite: word `w` appending to `v` by using a single rewriting `rule`.
+"""
+function rewrite_from_left!(
+    v::AbstractWord,
+    w::AbstractWord,
+    rule::Pair{<:AbstractWord, <:AbstractWord},
+)
+    lhs, rhs = rule
+    while !isone(w)
+        push!(v, popfirst!(w))
+        if issuffix(lhs, v)
+            prepend!(w, rhs)
+            resize!(v, length(v) - length(lhs))
+        end
+    end
+    return v
+end
+
+"""
     AbstractRewritingSystem{W,O}
 Abstract type representing rewriting system.
 
@@ -53,34 +93,10 @@ Base.isempty(s::RewritingSystem) = isempty(rules(s))
 
 Base.length(s::RewritingSystem) = length(rules(s))
 
-function rewrite_from_left!(
-    v::AbstractWord,
-    w::AbstractWord,
-    rule::Pair{<:AbstractWord, <:AbstractWord},
-)
-    lhs, rhs = rule
-    while !isone(w)
-        push!(v, popfirst!(w))
-        if issuffix(lhs, v)
-            prepend!(w, rhs)
-            resize!(v, length(v) - length(lhs))
-        end
-    end
-    return v
-end
-
-function rewrite_from_left(u::W, rule::Pair{<:AbstractWord, <:AbstractWord}) where {W<:AbstractWord}
-    T = eltype(u)
-    v = BufferWord{T}(0, length(u))
-    w = BufferWord{T}(u, 0, 0)
-    v = rewrite_from_left!(v, w, rule)
-    return W(v)
-end
-
 """
     rewrite_from_left!(v::AbstractWord, w::AbstractWord, rws::RewritingSystem)
 Rewrites word `w` from left using active rules from a given RewritingSystem and
-appends the result to `v`. For standard rewriting `v` should be empty.
+appends the result to `v`. For standard rewriting `v` should be empty. See [Sims, p.66]
 """
 function rewrite_from_left!(
     v::AbstractWord,
@@ -92,7 +108,6 @@ function rewrite_from_left!(
         for (i, (lhs, rhs)) in enumerate(rules(rws))
             KnuthBendix.isactive(rws, i) || continue
 
-            lenv = length(v)
             if issuffix(lhs, v)
                 prepend!(w, rhs)
                 resize!(v, length(v) - length(lhs))
@@ -100,20 +115,6 @@ function rewrite_from_left!(
         end
     end
     return v
-end
-
-"""
-    rewrite_from_left(u::AbstractWord, rs::RewritingSystem)
-Rewrites a word from left using active rules from a given RewritingSystem.
-See [Sims, p.66]
-"""
-function rewrite_from_left(u::W, rws::RewritingSystem) where {W<:AbstractWord}
-    isempty(rws) && return u
-    T = eltype(u)
-    v = BufferWord{T}(0, length(u))
-    w = BufferWord{T}(u, 0, 0)
-    v = rewrite_from_left!(v, w, rws)
-    return W(v)
 end
 
 function Base.show(io::IO, rws::RewritingSystem)

--- a/test/abstract_words.jl
+++ b/test/abstract_words.jl
@@ -157,7 +157,7 @@ function abstract_word_arithmetic_test(::Type{Wo}) where Wo
         @test occursin(u4, u2) == true
 
         @test findnext(isequal(2), u3, 1)  == 3
-        @test findnext(isequal(2), u3, 4)  == nothing
+        @test findnext(isequal(2), u3, 4)  === nothing
     end
 end
 

--- a/test/alphabets.jl
+++ b/test/alphabets.jl
@@ -9,10 +9,10 @@
 
     A = Alphabet{Char}()
     @test length(A.alphabet) == 0 && length(A.inversions) == 0
-    @test repr(A) isa String
+    @test sprint(show, A) isa String
 
     B = Alphabet(['a', 'b', 'c'])
-    @test repr(B) isa String
+    @test sprint(show, B) isa String
     @test B isa Alphabet{Char}
     @test length(B.alphabet) == 3 && length(B.inversions) == 3
     @test findfirst(i -> i != 0, B.inversions) === nothing

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -66,5 +66,5 @@
     ia = KnuthBendix.makeindexautomaton(rsc, A)
 
     testword = KnuthBendix.Word([1,1,1,1,1,2,2,2,3,4,2,2,3,3,3,4,4,4,4,3,4,3,4,1,2,1,1,1,1,1,1,1,2,1,3,4])
-    @test KnuthBendix.rewrite_from_left(testword, rsc) == KnuthBendix.index_rewrite(testword, ia)
+    @test KnuthBendix.rewrite_from_left(testword, rsc) == KnuthBendix.rewrite_from_left(testword, ia)
 end

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -8,10 +8,10 @@
 
     @test ta isa KnuthBendix.AbstractAutomaton
     @test ta isa KnuthBendix.Automaton
-    @test ta isa KnuthBendix.Automaton{UInt16, 4, Word{UInt16}}
+    @test ta isa KnuthBendix.Automaton{4, Word{UInt16}}
     @test σ isa KnuthBendix.AbstractState
     @test σ isa KnuthBendix.State
-    @test σ isa KnuthBendix.State{UInt16, 4, Word{UInt16}}
+    @test σ isa KnuthBendix.State{4, Word{UInt16}}
 
     @test KnuthBendix.name(σ) == Word(Int[])
     @test !KnuthBendix.isterminal(σ)

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -15,7 +15,8 @@
 
     @test KnuthBendix.name(σ) == Word(Int[])
     @test !KnuthBendix.isterminal(σ)
-    @test KnuthBendix.rightrule(σ) === nothing
+    @test KnuthBendix.rightrule(σ) == Word()
+
     @test length(KnuthBendix.states(ta)) == 1
     @test length(KnuthBendix.inedges(σ)) == 0
     @test length(KnuthBendix.outedges(σ)) == 4

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -5,6 +5,7 @@
     abt = KnuthBendix.Alphabet(['a', 'e', 'b', 'p'])
     ta = KnuthBendix.Automaton(abt)
     σ = KnuthBendix.initialstate(ta)
+    @test sprint(show, ta) isa String
 
     @test ta isa KnuthBendix.AbstractAutomaton
     @test ta isa KnuthBendix.Automaton

--- a/test/rewriting.jl
+++ b/test/rewriting.jl
@@ -75,4 +75,5 @@
     @test KnuthBendix.rules(empty!(z)) == KnuthBendix.rules(empty(s))
     @test KnuthBendix.rewrite_from_left(c, z) == c
 
+    @test sprint(show, z) isa String
 end


### PR DESCRIPTION
* add uniform `string_repr(w::AbstractWord, context)` where `context` could be either `Alphabet` or `Ordering` 
* cleaned-up `rewrite_from_left`
* simplified lots of signatures from `automata.jl`
* integrated `Automaton` and its rewriting into it
* some performance tunning, notably: added `_past_states` field to `Automaton` to be re-used in `rewrite_from_left`

```julia
using Test, BenchmarkTools, Random
using KnuthBendix
include("test/rws_examples.jl")
```
before:
```julia
julia> let R = RWS_Example_237_abaB(4), seed=1
           rws = KnuthBendix.knuthbendix2(R)

           n = length(KnuthBendix.alphabet(KnuthBendix.ordering(rws)))
           Random.seed!(seed)
           w = Word(rand(1:n, 2000))

           @btime KnuthBendix.rewrite_from_left($w, $rws)
           @time ia = KnuthBendix.makeindexautomaton(rws, KnuthBendix.alphabet(KnuthBendix.ordering(rws)))
           @btime KnuthBendix.index_rewrite($w, $ia)
       end;
  1.453 ms (5 allocations: 8.30 KiB)
  0.000742 seconds (4.76 k allocations: 218.672 KiB)
  242.169 μs (4430 allocations: 229.52 KiB)
```

after
```julia
julia> let R = RWS_Example_237_abaB(4), seed=1
           rws = KnuthBendix.knuthbendix2(R)

           n = length(KnuthBendix.alphabet(KnuthBendix.ordering(rws)))
           Random.seed!(seed)
           w = Word(rand(1:n, 2000))

           @btime KnuthBendix.rewrite_from_left($w, $rws)
           @time ia = KnuthBendix.makeindexautomaton(rws)
           @btime KnuthBendix.rewrite_from_left($w, $ia)
       end;
  1.170 ms (5 allocations: 8.30 KiB)
  0.000483 seconds (4.76 k allocations: 218.750 KiB)
  98.662 μs (5 allocations: 8.30 KiB)
```