### PR TITLE
Recursive path ordering

### DIFF
--- a/src/orderings.jl
+++ b/src/orderings.jl
@@ -32,11 +32,11 @@ end
 Base.hash(o::LenLex, h::UInt) = hash(o.A, hash(h, hash(LenLex)))
 
 """
-    lt(o::LenLex, p::T, q::T) where T<:AbstractWord{<:Integer}
+    lt(o::LenLex, p::AbstractWord, q::AbstractWord)
 
 Return whether the first word is less then the other one in a given LenLex ordering.
 """
-function lt(o::LenLex, p::T, q::T) where T<:AbstractWord{<:Integer}
+function lt(o::LenLex, p::AbstractWord, q::AbstractWord)
     if length(p) == length(q)
         for (a, b) in zip(p,q)
             a == b || return isless(a, b)  # comparing only on positive pointer values
@@ -62,11 +62,11 @@ end
 Base.hash(o::WreathOrder, h::UInt) = hash(o.A, hash(h, hash(WreathOrder)))
 
 """
-    lt(o::WreathOrder, p::T, q::T) where T<:AbstractWord{<:Integer}
+    lt(o::WreathOrder, p::AbstractWord, q::AbstractWord)
 
 Return whether the first word is less then the other one in a given WreathOrder ordering.
 """
-function lt(o::WreathOrder, p::T, q::T) where T<:AbstractWord{<:Integer}
+function lt(o::WreathOrder, p::AbstractWord, q::AbstractWord)
     iprefix = lcp(p, q) + 1
 
     @views pp = p[iprefix:end]
@@ -114,12 +114,12 @@ end
 Base.hash(o::RecursivePathOrder, h::UInt) = hash(o.A, hash(h, hash(RecursivePathOrder)))
 
 """
-    lt(o::RecursivePathOrder, p::T, q::T) where T<:AbstractWord{<:Integer}
+    lt(o::RecursivePathOrder, p::AbstractWord, q::AbstractWord)
 
 Return whether the first word is less then the other one in a given
 RecursivePathOrder ordering.
 """
-function lt(o::RecursivePathOrder, p::T, q::T) where T<:AbstractWord{<:Integer}
+function lt(o::RecursivePathOrder, p::AbstractWord, q::AbstractWord)
     isone(p) && return !isone(q)
     isone(q) && return false
 
@@ -128,9 +128,9 @@ function lt(o::RecursivePathOrder, p::T, q::T) where T<:AbstractWord{<:Integer}
 
     # i.e. we are not comparing single letter words
     @views begin
-        p[1:end] == q[2:end] && return true
-        lt(o, p[1:end], q[2:end]) && return true
-        first(p) < first(q) && lt(o, p[2:end], q[1:end]) && return true
+        p == q[2:end] && return true
+        lt(o, p, q[2:end]) && return true
+        first(p) < first(q) && lt(o, p[2:end], q) && return true
         first(p) == first(q) && lt(o, p[2:end], q[2:end]) && return true
     end
     return false

--- a/src/orderings.jl
+++ b/src/orderings.jl
@@ -102,6 +102,10 @@ end
 Structure representing Recursive Path Ordering (determined by the Lexicographic
 ordering of the Alphabet) of the words over given Alphabet. This Lexicographinc
 ordering of an Alphabet is implicitly specified inside Alphabet struct.
+For the definition see
+> Susan M.Hermiller, Rewriting systems for Coxeter groups
+> _Journal of Pure and Applied Algebra_
+> Volume 92, Issue 2, 7 March 1994, Pages 137-148.
 """
 struct RecursivePathOrder{T} <: WordOrdering
     A::Alphabet{T}

--- a/src/orderings.jl
+++ b/src/orderings.jl
@@ -2,18 +2,33 @@ import Base.Order: lt, Ordering
 export LenLex, WreathOrder
 
 """
-    struct LenLex{T} <: Ordering
+    WordOrdering <: Ordering
+Abstract type representing word orderings.
+
+The subtypes of `WordOrdering` should contain a field `A` storing the `Alphabet`
+over which a particular order is defined. Morever an `Base.lt` method should be
+defined to compare whether one word is less than the other (in the ordering
+defined).
+"""
+abstract type WordOrdering <: Ordering end
+
+
+alphabet(o::WordOrdering) = o.A
+Base.:(==)(o1::T, o2::T) where {T<:WordOrdering} = alphabet(o1) == alphabet(o2)
+string_repr(W::AbstractWord, o::WordOrdering) = string_repr(W, alphabet(o))
+
+
+"""
+    struct LenLex{T} <: WordOrdering
 
 Basic structure representing Length+Lexicographic (left-to-right) ordering of
 the words over given Alphabet. Lexicographic ordering of an Alphabet is
 implicitly specified inside Alphabet struct.
 """
-struct LenLex{T} <: Ordering
+struct LenLex{T} <: WordOrdering
     A::Alphabet{T}
 end
 
-alphabet(o::LenLex) = o.A
-Base.:(==)(o1::LenLex, o2::LenLex) = alphabet(o1) == alphabet(o2)
 Base.hash(o::LenLex, h::UInt) = hash(o.A, hash(h, hash(LenLex)))
 
 """
@@ -32,22 +47,18 @@ function lt(o::LenLex, p::T, q::T) where T<:AbstractWord{<:Integer}
     end
 end
 
-string_repr(W::AbstractWord, o::Ordering) = string_repr(W, alphabet(o))
-
 
 """
-    struct WreathOrder{T} <: Ordering
+    struct WreathOrder{T} <: WordOrdering
 
 Structure representing basic wreath-product ordering (determined by the Lexicographic
 ordering of the Alphabet) of the words over given Alphabet. This Lexicographinc
 ordering of an Alphabet is implicitly specified inside Alphabet struct.
 """
-struct WreathOrder{T} <: Ordering
+struct WreathOrder{T} <: WordOrdering
     A::Alphabet{T}
 end
 
-alphabet(o::WreathOrder) = o.A
-Base.:(==)(o1::WreathOrder, o2::WreathOrder) = alphabet(o1) == alphabet(o2)
 Base.hash(o::WreathOrder, h::UInt) = hash(o.A, hash(h, hash(WreathOrder)))
 
 """

--- a/src/orderings.jl
+++ b/src/orderings.jl
@@ -103,7 +103,7 @@ Structure representing Recursive Path Ordering (determined by the Lexicographic
 ordering of the Alphabet) of the words over given Alphabet. This Lexicographinc
 ordering of an Alphabet is implicitly specified inside Alphabet struct.
 For the definition see
-> Susan M.Hermiller, Rewriting systems for Coxeter groups
+> Susan M. Hermiller, Rewriting systems for Coxeter groups
 > _Journal of Pure and Applied Algebra_
 > Volume 92, Issue 2, 7 March 1994, Pages 137-148.
 """
@@ -127,11 +127,11 @@ function lt(o::RecursivePathOrder, p::T, q::T) where T<:AbstractWord{<:Integer}
     length(p) == 1 && length(q) == 1 && return (first(p) < first(q))
 
     # i.e. we are not comparing single letter words
-    if first(p) == first(q)
-        @views lt(o, p[2:end], q[2:end]) && return true
-    elseif first(p) < first(q)
-        @views lt(o, p[2:end], q[1:end]) && return true
+    @views begin
+        p[1:end] == q[2:end] && return true
+        lt(o, p[1:end], q[2:end]) && return true
+        first(p) < first(q) && lt(o, p[2:end], q[1:end]) && return true
+        first(p) == first(q) && lt(o, p[2:end], q[2:end]) && return true
     end
-    @views p == q[2:end] && return true
-    @views return lt(o, p[1:end], q[2:end])
+    return false
 end

--- a/test/orderings.jl
+++ b/test/orderings.jl
@@ -38,14 +38,21 @@
 
     @test sort(a, order = wo) == [ε, w1, w2, w3, w4, w5, w6]
 
-    rpo = WreathOrder(A)
+    rpo = RecursivePathOrder(A)
 
     w1 = Word([1])
+    w2 = Word([2])
     w14 = Word([1,4])
     w214 = Word([2,1,4])
+    w41 = Word([4,1])
+    w241 = Word([2,4,1])
     w1224 = Word([1,2,3,2,1,4,2,4])
+    w32141 = Word([3,2,1,4,1])
 
     a = [w14, w1, w1224, w214, ε]
+    b = [w32141, w214, w1, ε, w241, w2, w41]
 
-    @test sort(a, order = wo) == [ε, w1, w14, w214, w1224]
+    @test sort(a, order = rpo) == [ε, w1, w14, w214, w1224]
+    @test sort(b, order = rpo) == [ε, w1, w2, w214, w41, w241, w32141]
+
 end

--- a/test/orderings.jl
+++ b/test/orderings.jl
@@ -24,6 +24,7 @@
     @test lt(lenlexord, u1, u1) == false
 
     wo = WreathOrder(A)
+    @test wo isa KnuthBendix.WordOrdering
 
     w1 = Word([3,1,4,2,3])
     w5 = Word([1,2,3,2,4,1,2,4])

--- a/test/orderings.jl
+++ b/test/orderings.jl
@@ -26,6 +26,7 @@
     wo = WreathOrder(A)
     @test wo isa KnuthBendix.WordOrdering
 
+    ε = Word()
     w1 = Word([3,1,4,2,3])
     w5 = Word([1,2,3,2,4,1,2,4])
     w4 = Word([1,3,1,2,4,2,1])
@@ -33,8 +34,18 @@
     w2 = Word([1,3,4,3,2])
     w3 = Word([1,3,2,1,4,1,2])
 
-    a = [w1, w5, w4, w6, w2, w3]
+    a = [w1, w5, w4, w6, w2, w3, ε]
 
-    @test sort(a, order = wo) == [w1, w2, w3, w4, w5, w6]
+    @test sort(a, order = wo) == [ε, w1, w2, w3, w4, w5, w6]
 
+    rpo = WreathOrder(A)
+
+    w1 = Word([1])
+    w14 = Word([1,4])
+    w214 = Word([2,1,4])
+    w1224 = Word([1,2,3,2,1,4,2,4])
+
+    a = [w14, w1, w1224, w214, ε]
+
+    @test sort(a, order = wo) == [ε, w1, w14, w214, w1224]
 end

--- a/test/rws_examples.jl
+++ b/test/rws_examples.jl
@@ -97,6 +97,35 @@ end
 
 RWS_Example_6_6() = RWS_Example_237_abaB(8)
 
+function RWS_Closed_Orientable_Surface(n)
+    ltrs = String[]
+    for i in 1:n
+        subscript = join('₀'+d for d in reverse(digits(i)))
+        append!(ltrs, ["a" * subscript, "A" * subscript, "b" * subscript, "B" * subscript])
+    end
+    Al = Alphabet(reverse!(ltrs))
+    for i in 1:n
+        subscript = join('₀'+d for d in reverse(digits(i)))
+        KnuthBendix.set_inversion!(Al, "a" * subscript, "A" * subscript)
+        KnuthBendix.set_inversion!(Al, "b" * subscript, "B" * subscript)
+    end
+
+    ε = Word()
+    rules = Pair{typeof(ε), typeof(ε)}[]
+    word = Int[]
+
+    for i in reverse(1:n)
+        x = 4 * i
+        append!(rules, [Word([x-1, x]) => ε, Word([x, x-1]) => ε])
+        append!(rules, [Word([x-3, x-2]) => ε, Word([x-2, x-3]) => ε])
+        append!(word, [x, x-2, x-1, x-3])
+    end
+    push!(rules, Word(word) => ε)
+    R = RewritingSystem(rules, RecursivePathOrder(Al))
+
+    return R
+end
+
 
 @testset "KBS1 examples" begin
     R = RWS_Example_5_1()
@@ -133,6 +162,10 @@ RWS_Example_6_6() = RWS_Example_237_abaB(8)
     R = RWS_Example_6_5()
     rws = KnuthBendix.knuthbendix1(R, maxrules=100)
     @test_broken length(rws) == 56
+
+    R = RWS_Closed_Orientable_Surface(3)
+    rws = KnuthBendix.knuthbendix1(R)
+    @test length(rws) == 16
 end
 
 @testset "KBS2 examples" begin
@@ -173,4 +206,8 @@ end
     R = RWS_Example_6_5()
     rws = KnuthBendix.knuthbendix2(R)
     @test length(rws) == 40
+
+    R = RWS_Closed_Orientable_Surface(3)
+    rws = KnuthBendix.knuthbendix1(R)
+    @test length(rws) == 16
 end


### PR DESCRIPTION
This closes #32. I checked and this ordering produces the right `RewritingSystem` for a system representing the fundamental group of closed orientable surface of genus 3 as reported in [Hermiller, S. M.: Rewriting systems for Coxeter groups](https://doi.org/10.1016/0022-4049(94)90019-1).

As a side note: `LenLex` does not produce a finite system within the limit of `maxrules` for this example, whereas `WreathOrder` does and it is the same system as for `RecursivePathOrder`.