### PR TITLE
Kbs automata integration

### DIFF
--- a/src/KnuthBendix.jl
+++ b/src/KnuthBendix.jl
@@ -11,4 +11,5 @@ include("rewriting.jl")
 include("kbs1.jl")
 include("kbs2.jl")
 include("automata.jl")
+include("automata_kbs2.jl")
 end

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -271,7 +271,6 @@ function makeindexautomaton(rws::RewritingSystem, abt::Alphabet=alphabet(orderin
                 σ = outedges(σ)[letter]
             else
                 push!(a, lhs[1:i])
-                # push!(Σᵢ, i)
                 addedge!(a, letter, σ, states(a)[end])
                 σ = states(a)[end]
             end
@@ -284,8 +283,8 @@ function makeindexautomaton(rws::RewritingSystem, abt::Alphabet=alphabet(orderin
         end
     end
     # Determining cross paths
-    for state in outedges(initialstate(a))
-        isnoedge(state) && addedge!(a, state, 1, 1)
+    for (i, state) in enumerate(outedges(initialstate(a)))
+        isnoedge(state) && addedge!(a, i, 1, 1)
     end
     i = 1
     indcs = findall(isequal(i), stateslengths(a))
@@ -311,7 +310,7 @@ to `v`. For standard rewriting `v` should be empty.
 """
 function rewrite_from_left!(v::AbstractWord, w::AbstractWord, a::Automaton)
     past_states = a._past_states
-    resize!(past_states, length(w))
+    resize!(past_states, length(w) + 1)
     state = initialstate(a)
     past_states[1] = state
     initial_length = length(v)

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -263,23 +263,25 @@ Creates index automaton corresponding to a given rewriting system.
 function makeindexautomaton(rws::RewritingSystem, abt::Alphabet=alphabet(ordering(rws)))
     a = Automaton(abt)
     # Determining simple paths
-    for (lhs, rhs) in rules(rws)
-        σ = initialstate(a)
-        for (i, letter) in enumerate(lhs)
-            if !isnoedge(outedges(σ)[letter])
-                σ = outedges(σ)[letter]
-            else
-                push!(a, lhs[1:i])
-                # push!(Σᵢ, i)
-                addedge!(a, letter, σ, states(a)[end])
-                σ = states(a)[end]
+    for (idx, (lhs, rhs)) in enumerate(rules(rws))
+        if isactive(rws, idx)
+            σ = initialstate(a)
+            for (i, letter) in enumerate(lhs)
+                if !isnoedge(outedges(σ)[letter])
+                    σ = outedges(σ)[letter]
+                else
+                    push!(a, lhs[1:i])
+                    # push!(Σᵢ, i)
+                    addedge!(a, letter, σ, states(a)[end])
+                    σ = states(a)[end]
+                end
             end
-        end
-        terminal = states(a)[end]
-        declarerightrule!(terminal, rhs)
-        # Add loops for terminal state
-        for i in 1:length(outedges(terminal))
-            addedge!(a, i, terminal, terminal)
+            terminal = states(a)[end]
+            declarerightrule!(terminal, rhs)
+            # Add loops for terminal state
+            for i in 1:length(outedges(terminal))
+                addedge!(a, i, terminal, terminal)
+            end
         end
     end
     # Determining cross paths

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -299,13 +299,16 @@ function makeindexautomaton!(a::Automaton, rws::RewritingSystem, abt::Alphabet=a
     while !isempty(indcs)
         for idx in indcs
             σ = states(a)[idx]
-            τ = walk(a, name(σ)[2:end])[2]
+            τ = walk(a, @view(name(σ)[2:end]))[2]
             for (letter, state) in enumerate(outedges(σ))
                 isnoedge(state) && addedge!(a, letter, σ, outedges(τ)[letter])
             end
         end
         i += 1
-        indcs = findall(isequal(i), stateslengths(a))
+        resize!(indcs, 0)
+        for (k,len) in enumerate(stateslengths(a))
+            len == i && push!(indcs, k)
+        end
     end
     return a
 end
@@ -338,10 +341,11 @@ function rewrite_from_left!(v::AbstractWord, w::AbstractWord, a::Automaton)
     resize!(past_states, length(w) + 1)
     state = initialstate(a)
     past_states[1] = state
+    initial_length = length(v)
 
     while !isone(w)
         x = popfirst!(w)
-        k = length(v) + 1
+        k = length(v) - initial_length + 1
         state = outedges(past_states[k])[x]
 
         if !isterminal(state)

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -264,24 +264,23 @@ function makeindexautomaton(rws::RewritingSystem, abt::Alphabet=alphabet(orderin
     a = Automaton(abt)
     # Determining simple paths
     for (idx, (lhs, rhs)) in enumerate(rules(rws))
-        if isactive(rws, idx)
-            σ = initialstate(a)
-            for (i, letter) in enumerate(lhs)
-                if !isnoedge(outedges(σ)[letter])
-                    σ = outedges(σ)[letter]
-                else
-                    push!(a, lhs[1:i])
-                    # push!(Σᵢ, i)
-                    addedge!(a, letter, σ, states(a)[end])
-                    σ = states(a)[end]
-                end
+        isactive(rws, idx) || continue
+        σ = initialstate(a)
+        for (i, letter) in enumerate(lhs)
+            if !isnoedge(outedges(σ)[letter])
+                σ = outedges(σ)[letter]
+            else
+                push!(a, lhs[1:i])
+                # push!(Σᵢ, i)
+                addedge!(a, letter, σ, states(a)[end])
+                σ = states(a)[end]
             end
-            terminal = states(a)[end]
-            declarerightrule!(terminal, rhs)
-            # Add loops for terminal state
-            for i in 1:length(outedges(terminal))
-                addedge!(a, i, terminal, terminal)
-            end
+        end
+        terminal = states(a)[end]
+        declarerightrule!(terminal, rhs)
+        # Add loops for terminal state
+        for i in 1:length(outedges(terminal))
+            addedge!(a, i, terminal, terminal)
         end
     end
     # Determining cross paths

--- a/src/automata_kbs2.jl
+++ b/src/automata_kbs2.jl
@@ -1,5 +1,5 @@
 """
-    deriverule!(rs::RewritingSystem, stack[, o::Ordering=ordering(rs)])
+    deriverule!(rs::RewritingSystem, at::Automaton, stack[, o::Ordering=ordering(rs)])
 Adds a rule to a rewriting system and deactivates others (if necessary) that
 insures that the set of rules is reduced while maintining local confluence.
 See [Sims, p. 76].
@@ -37,7 +37,7 @@ function deriverule!(rs::RewritingSystem, at::Automaton, stack, o::Ordering = or
 end
 
 """
-    forceconfluence!(rs::RewritingSystem, stack, i::Integer, j::Integer
+    forceconfluence!(rs::RewritingSystem, at::Automaton, stack, i::Integer, j::Integer
     [, o::Ordering=ordering(rs)])
 Checks the proper overlaps of right sides of active rules at position i and j
 in the rewriting system. When failures of local confluence are found, new rules
@@ -61,7 +61,7 @@ function forceconfluence!(rs::RewritingSystem, at::Automaton, stack, i::Integer,
 end
 
 """
-    knuthbendix2!(rws::RewritingSystem[, o::Ordering=ordering(rws);
+    knuthbendix2automaton!((rws::RewritingSystem[, o::Ordering=ordering(rws);
     maxrules::Integer=100])
 Implements the Knuth-Bendix completion algorithm that yields a reduced,
 confluent rewriting system. See [Sims, p.77].

--- a/src/automata_kbs2.jl
+++ b/src/automata_kbs2.jl
@@ -1,0 +1,110 @@
+"""
+    deriverule!(rs::RewritingSystem, stack[, o::Ordering=ordering(rs)])
+Adds a rule to a rewriting system and deactivates others (if necessary) that
+insures that the set of rules is reduced while maintining local confluence.
+See [Sims, p. 76].
+"""
+function deriverule!(rs::RewritingSystem, at::Automaton, stack, o::Ordering = ordering(rs))
+    temporary_rws = empty(rs)
+    if length(stack) >= 2
+        @debug "Deriving rules with stack of length=$(length(stack))"
+    end
+    while !isempty(stack)
+        lr, rr = pop!(stack)
+        a = rewrite_from_left(lr, at)
+        b = rewrite_from_left(rr, at)
+        if a != b
+            if lt(o, a, b)
+                a, b = b, a
+            end
+
+            rule = a => b
+            push!(rs, rule)
+            push!(temporary_rws, rule)
+
+            for i in 1:length(rules(rs))-1
+                isactive(rs, i) || continue
+                (lhs, rhs) = rules(rs)[i]
+                if occursin(a, lhs)
+                    setinactive!(rs, i)
+                    push!(stack, lhs => rhs)
+                elseif occursin(a, rhs)
+                    new_rhs = rewrite_from_left(rhs, temporary_rws)
+                    rules(rs)[i] = (lhs => rewrite_from_left(new_rhs, a))
+                    # Now it is crucial to somewhere reconstruct automaton
+                end
+            end
+        end
+    end
+end
+
+"""
+    forceconfluence!(rs::RewritingSystem, stack, i::Integer, j::Integer
+    [, o::Ordering=ordering(rs)])
+Checks the proper overlaps of right sides of active rules at position i and j
+in the rewriting system. When failures of local confluence are found, new rules
+are added. See [Sims, p. 77].
+"""
+function forceconfluence!(rs::RewritingSystem, at::Automaton, stack, i::Integer, j::Integer, o::Ordering = ordering(rs))
+    lhs_i, rhs_i = rules(rs)[i]
+    lhs_j, rhs_j = rules(rs)[j]
+    m = min(length(lhs_i), length(lhs_j)) - 1
+    k = 1
+
+    while k ≤ m && isactive(rs, i) && isactive(rs, j)
+        if issuffix(lhs_j, lhs_i, k)
+            a = lhs_i[1:end-k]; append!(a, rhs_j)
+            c = lhs_j[k+1:end]; prepend!(c, rhs_i);
+            push!(stack, a => c)
+            deriverule!(rs, at, stack, o)
+            at = makeindexautomaton(rs)
+        end
+        k += 1
+    end
+end
+
+"""
+    knuthbendix2!(rws::RewritingSystem[, o::Ordering=ordering(rws);
+    maxrules::Integer=100])
+Implements the Knuth-Bendix completion algorithm that yields a reduced,
+confluent rewriting system. See [Sims, p.77].
+
+Warning: forced termiantion takes place after the number of rules stored within
+the RewritngSystem reaches `maxrules`.
+"""
+function knuthbendix2automaton!(rws::RewritingSystem,
+    o::Ordering = ordering(rws); maxrules::Integer = 100)
+    stack = copy(rules(rws)[active(rws)])
+    rws = empty!(rws)
+    deriverule!(rws, stack)  # We skip using empty automaton for rewriting here
+    at = makeindexautomaton(rws)
+
+    i = 1
+    while i ≤ (length(rules(rws)))
+        # @debug "number_of_active_rules" sum(active(rws))
+        if sum(active(rws)) > maxrules
+            @warn("Maximum number of rules ($maxrules) in the RewritingSystem reached.
+                You may retry with `maxrules` kwarg set to higher value.")
+            break
+        end
+        j = 1
+        while (j ≤ i && isactive(rws, i))
+            if isactive(rws, j)
+                forceconfluence!(rws, at, stack, i, j, o)
+                if j < i && isactive(rws, i) && isactive(rws, j)
+                    forceconfluence!(rws, at, stack, j, i, o)
+                end
+            end
+            j += 1
+        end
+        i += 1
+    end
+    deleteat!(rules(rws), .!active(rws))
+    resize!(active(rws), length(rules(rws)))
+    active(rws) .= true
+    return rws
+end
+
+function knuthbendix2automaton(rws::RewritingSystem; maxrules::Integer = 100)
+    knuthbendix2!(deepcopy(rws), maxrules=maxrules)
+end

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -21,6 +21,7 @@
     @test length(KnuthBendix.states(ta)) == 1
     @test length(KnuthBendix.inedges(σ)) == 0
     @test length(KnuthBendix.outedges(σ)) == 4
+    @test length(KnuthBendix.stateslengths(ta)) == 1
     @test length(σ) == 0
 
     KnuthBendix.declarerightrule!(σ, Word())
@@ -43,6 +44,7 @@
     KnuthBendix.addedge!(ta, 1, 1, 2)
     deleteat!(ta, 2)
     @test length(KnuthBendix.states(ta)) == 1
+    @test length(KnuthBendix.stateslengths(ta)) == 1
     @test KnuthBendix.isnoedge(KnuthBendix.outedges(σ)[1])
 
     A = KnuthBendix.Alphabet(['a', 'e', 'b', 'p'])

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -71,4 +71,7 @@
 
     testword = KnuthBendix.Word([1,1,1,1,1,2,2,2,3,4,2,2,3,3,3,4,4,4,4,3,4,3,4,1,2,1,1,1,1,1,1,1,2,1,3,4])
     @test KnuthBendix.rewrite_from_left(testword, rsc) == KnuthBendix.rewrite_from_left(testword, ia)
+
+    w = KnuthBendix.Word([1,3,4,1,4,4,1,1,4,2,3,2,4,2,2,3,1,2,1])
+    @test KnuthBendix.rewrite_from_left(w, rsc) == KnuthBendix.rewrite_from_left(w, ia)
 end

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -74,4 +74,11 @@
 
     w = KnuthBendix.Word([1,3,4,1,4,4,1,1,4,2,3,2,4,2,2,3,1,2,1])
     @test KnuthBendix.rewrite_from_left(w, rsc) == KnuthBendix.rewrite_from_left(w, ia)
+
+    @test !isempty(ia)
+    @test isempty(empty!(ia))
+
+    rsd = KnuthBendix.RewritingSystem([a=>ε, b=>ε], lenlexord)
+    iad = KnuthBendix.makeindexautomaton(rsd, A)
+    @test KnuthBendix.rewrite_from_left(testword, rsd) == KnuthBendix.rewrite_from_left(testword, iad)
 end

--- a/test/automata_kbs2.jl
+++ b/test/automata_kbs2.jl
@@ -1,0 +1,31 @@
+@testset "automata_KBS2" begin
+
+    A = Alphabet(['a', 'e', 'b', 'p'])
+    KnuthBendix.set_inversion!(A, 'a', 'e')
+    KnuthBendix.set_inversion!(A, 'b', 'p')
+
+    a = Word([1,2])
+    b = Word([2,1])
+    c = Word([3,4])
+    d = Word([4,3])
+    ε = Word()
+
+    ba = Word([3,1])
+    ab = Word([1,3])
+
+    be = Word([3,2])
+    eb = Word([2,3])
+
+    pa = Word([4,1])
+    ap = Word([1,4])
+
+    pe = Word([4,2])
+    ep = Word([2,4])
+
+    lenlexord = LenLex(A)
+    rs = RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab], lenlexord)
+
+    crs = Set([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, be=>eb, pa=>ap, pe=>ep])
+
+    @test Set(KnuthBendix.rules(KnuthBendix.knuthbendix2automaton(rs))) == crs
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ include("abstract_words.jl")
 @testset "KnuthBendix.jl" begin
    include("words.jl")
    include("bufferwords.jl")
-
+   include("automata_kbs2.jl")
    include("alphabets.jl")
    include("orderings.jl")
    include("rewriting.jl")


### PR DESCRIPTION
So this is a very crude integration of Index Automata with Knuth-Bendix procedure (2nd version) - the automaton is updated (i.e. `makeindexautomaton!` is run) every time the `RewritingSystem` is updated. Other changes:

- `Automata` are slightly redesigned (new field `stateslengths` which was moved from the `makeindexautomaton`);
- updated `makeindexautomaton`;
- I think that at some point an error got into `rewrite_from_left` which uses `Automaton` - which I corrected.

I will also add more tests: publishing it so that you can have a look.

And of course a quick benchmark:
```julia
using KnuthBendix
using BenchmarkTools
using Random
using Test
include("test/rws_examples.jl")


let R = RWS_Example_237_abaB(4), seed=1
    @btime KnuthBendix.knuthbendix2($R)
    @btime KnuthBendix.knuthbendix2automaton($R)
end;
```

which gives:
```julia
  30.099 ms (22105 allocations: 1.76 MiB)
  11.942 ms (145458 allocations: 11.56 MiB)
```

So even though we update the automaton every time the `RewritingSystem` changes we are faster than normal `kbs2`.