### PR TITLE
change the order of args in Base.inv (Alphabet goes first)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,14 @@
 name = "KnuthBendix"
 uuid = "c2604015-7b3d-4a30-8a26-9074551ec60a"
-authors = ["Marek Kaluba <kalmar@amu.edu.pl>"]
+authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "Mikołaj Pabiszczak <mikolaj.pabiszczak@gmail.com>"]
 version = "0.1.0"
+
+[deps]
+Groups = "5d8bd718-bd84-11e8-3b40-ad14f4a32557"
 
 [compat]
 julia = "1"
+Groups = "^0.5.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/alphabets.jl
+++ b/src/alphabets.jl
@@ -37,14 +37,15 @@ Alphabet(x::Vector{T}; safe = true) where T = Alphabet{T}(x; safe = safe)
 
 Base.length(abt::Alphabet) = length(abt.alphabet)
 Base.isempty(A::Alphabet) = isempty(A.alphabet)
-Base.:(==)(A::Alphabet, B::Alphabet) = A.alphabet == B.alphabet && A.inversions == B.inversions
+Base.:(==)(A::Alphabet, B::Alphabet) =
+    A.alphabet == B.alphabet && A.inversions == B.inversions
 Base.hash(A::Alphabet{T}, h::UInt) where T =
     hash(A.alphabet, hash(A.inversions, hash(h, hash(Alphabet{T}))))
 
 Base.show(io::IO, A::Alphabet{T}) where T = print(io, Alphabet{T}, A.alphabet)
 
 hasinverse(i::Integer, A::Alphabet) = A.inversions[i] > 0
-hasinverse(l::T, A::Alphabet{T}) where T = hasinverse(findfirst(==(l), A.alphabet), A)
+hasinverse(l::T, A::Alphabet{T}) where T = hasinverse(A[l], A)
 
 function Base.show(io::IO, ::MIME"text/plain", A::Alphabet{T}) where T
     if isempty(A)
@@ -229,15 +230,16 @@ end
     inv(w::AbstractWord, A::Alphabet)
 Return the inverse of a word `w` in the context of alphabet `A`.
 """
-function Base.inv(w::AbstractWord, A::Alphabet)
+function Base.inv(A::Alphabet, w::AbstractWord)
     res = similar(w)
     n = length(w)
-    for i in eachindex(w)
-        iszero(A.inversions[w[i]]) && throw(DomainError(w, "is not invertible over $A"))
-        res[n+1-i] = A.inversions[w[i]]
+    for (i,l) in enumerate(reverse(w))
+        hasinverse(l, A) || throw(DomainError(w, "is not invertible over $A"))
+        res[i] = A.inversions[l]
     end
     return res
 end
+Base.inv(A::Alphabet{T}, a::T) where {T} = A[-A[a]]
 
 string_repr(w::AbstractWord, A::Alphabet) =
     (isone(w) ? "(empty word)" : join((A[i] for i in w), "*"))


### PR DESCRIPTION
example presentation here:
https://gist.github.com/kalmarek/c2084af80d746807df221a5f4b38cad1

```julia
let (rels, A) = gersten_relations(3, commutative = false), order = LenLex(A), maxr = 1000
    let rws = RewritingSystem(rels, order)
        @time KnuthBendix.knuthbendix2!(rws, maxrules = maxr)
    end

    let rws = RewritingSystem(rels, order)
        @time KnuthBendix.knuthbendix2automaton!(rws, maxrules = maxr)
    end
end
```
timing:
```
┌ Warning: Maximum number of rules (1000) in the RewritingSystem reached.
│                 You may retry with `maxrules` kwarg set to higher value.
└ @ KnuthBendix ~/.julia/dev/KnuthBendix/src/kbs2.jl:81
  0.246382 seconds (41.12 k allocations: 2.799 MiB)
┌ Warning: Maximum number of rules (1000) in the RewritingSystem reached.
│                 You may retry with `maxrules` kwarg set to higher value.
└ @ KnuthBendix ~/.julia/dev/KnuthBendix/src/automata_kbs2.jl:83
 35.760633 seconds (15.53 M allocations: 2.042 GiB, 1.18% gc time)
```
i.e. rebuilding the automaton is very expensive, especially when there are lots of words inserted.

Corollary: the other example stresses the performance of rewriting. this one stresses the performance of building/changing the automaton.

I think it'll be better to integrate KnuthBendix with Groups, not the other way round.