### PR TITLE
Fix/simplifyrule!

### DIFF
--- a/test/abstract_words.jl
+++ b/test/abstract_words.jl
@@ -121,6 +121,7 @@ function abstract_word_indexing_test(::Type{Wo}) where Wo
         @test_throws BoundsError W[-1]
         @test_throws BoundsError W[lw+3]
 
+        @test @view(W[2:3]) isa KnuthBendix.AbstractWord
     end
 end
 

--- a/test/rewriting.jl
+++ b/test/rewriting.jl
@@ -77,10 +77,17 @@
     @test KnuthBendix.rewrite_from_left(c, z) == c
 
     push!(A, "z")
-    w1 = Word([1,2,3,2,5,1,2,2,2,2])
-    w2 = Word([1,2,3,2,5,1,2,1,1,1])
-    KnuthBendix.simplifyrule!(w1, w2, A)
-    @test (w1, w2) == (Word([5,1,2,2,2,2]), Word([5,1,2,1,1,1]))
+
+    prefix = Word(rand(1:length(A)-1, 100)) # all invertible
+    suffix = Word(rand(1:length(A)-1, 100)) # all invertible
+    l = Word([5,1,2,2])
+    r = Word([5,1,2,1])
+
+    @test KnuthBendix.simplifyrule!(prefix*l, prefix*r, A) == (l, r)
+    @test KnuthBendix.simplifyrule!(l*suffix, r*suffix, A) == (l, r)
+    @test KnuthBendix.simplifyrule!(prefix*l*suffix, prefix*r*suffix, A) == (l, r)
+    @test KnuthBendix.simplifyrule!(l*suffix, prefix*r*Word([5]), A) == (l*suffix, prefix*r*Word([5]))
+    @test KnuthBendix.simplifyrule!(copy(l), copy(r), A) == (l, r)
 
     @test sprint(show, z) isa String
 end


### PR DESCRIPTION
The bug in #40 has probably nothing to do with `BufferWords`, but is most probably an off-by-one index in `simplifyrules!`.

Closes #40 