### PR TITLE
Enh/deprecate word()

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,11 +1,15 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 0 * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ jobs:
       matrix:
         version:
           - '1.0'
-          - '1.4'
-          - '1.5'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/src/abstract_words.jl
+++ b/src/abstract_words.jl
@@ -5,7 +5,7 @@ Abstract type representing words over an Alphabet.
 `AbstractWord` as such has its meaning only in the contex of an Alphabet.
 The subtypes of `AbstractWord{T}` need to implement the following methods which
 constitute `AbstractWord` interface:
- * `W()`: empty constructor returning the identity (e.g. empty) element
+ * a constructor from `AbstractVector{T}`
  * linear indexing (1-based) consistent with iteration returning pointers to letters of an alphabet (`getindex`, `setindex`, `length`),
  * `length`: the length of word as written in the alphabet,
  * `Base.push!`/`Base.pushfirst!`: appending a single value at the end/beginning,
@@ -23,11 +23,8 @@ performance reasons:
 
 * `Base.==`: the equality (as words),
 * `Base.hash`: simple uniqueness hashing function
-* `Base.isone`: predicate checking if argument represents the empty word (i.e. monoid identity element)
 * `Base.view`: creating `SubWord` e.g. based on subarray.
-
 """
-
 abstract type AbstractWord{T<:Integer} <: AbstractVector{T} end
 
 Base.hash(w::AbstractWord, h::UInt) =
@@ -37,8 +34,9 @@ Base.hash(w::AbstractWord, h::UInt) =
 
 Base.size(w::AbstractWord) = (length(w),)
 
-Base.one(::Type{W}) where W <: AbstractWord = W()
-Base.one(::W) where W <: AbstractWord = W()
+Base.one(::Type{W}) where {T, W<:AbstractWord{T}} = W(T[])
+Base.one(::W) where W <: AbstractWord = one(W)
+Base.isone(w::AbstractWord) = iszero(length(w))
 
 Base.getindex(w::W, u::AbstractRange) where W<:AbstractWord =
     W([w[i] for i in u])

--- a/src/abstract_words.jl
+++ b/src/abstract_words.jl
@@ -8,15 +8,15 @@ constitute `AbstractWord` interface:
  * a constructor from `AbstractVector{T}`
  * linear indexing (1-based) consistent with iteration returning pointers to letters of an alphabet (`getindex`, `setindex`, `length`),
  * `length`: the length of word as written in the alphabet,
- * `Base.push!`/`Base.pushfirst!`: appending a single value at the end/beginning,
- * `Base.pop!`/`Base.popfirst!`: popping a single value from the end/beginning,
- * `Base.append!`/`Base.prepend!`: appending a another word at the end/beginning,
- * `Base.resize!`: dropping/extending a word at the end to the requested length
+ * `Base.push!`/`Base.pushfirst!`: append a single value at the end/beginning,
+ * `Base.pop!`/`Base.popfirst!`: pop a single value from the end/beginning,
+ * `Base.append!`/`Base.prepend!`: append a another word at the end/beginning,
+ * `Base.resize!`: drop/extend a word at the end to the requested length
  * `Base.:*`: word concatenation (monoid binary operation),
  * `Base.similar`: an uninitialized word of a similar type/storage.
 
-Note that `length` represents how word is written and not the shortest form of
-e.g. free reduced word.
+Note that `length` represents free reduced word (how it is written in an alphabet)
+and not its the shortest form (e.g. the normal form).
 
 The following are implemented for `AbstractWords` but can be overloaded for
 performance reasons:

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -51,7 +51,7 @@ mutable struct State{N, W<:AbstractWord} <: AbstractState{N, W}
         s = State{N, W}()
         s.name = name
         s.terminal = false
-        s.rrule = W()
+        s.rrule = one(W)
         s.ined = typeof(s)[]
         s.outed = ntuple(i -> noedge, N)
         s.representsnoedge = false
@@ -136,7 +136,7 @@ end
 function Automaton(abt::Alphabet, W::Type{<:AbstractWord}=Word{UInt16})
     S = State{length(abt), W}
     uniquenoedge = S()
-    Automaton{length(abt), W}([State(W(), uniquenoedge)], abt, uniquenoedge, [0], S[])
+    Automaton{length(abt), W}([State(one(W), uniquenoedge)], abt, uniquenoedge, [0], S[])
 end
 
 alphabet(a::Automaton) = a.abt
@@ -151,8 +151,10 @@ function Base.isempty(a::Automaton)
     return false
 end
 
-Base.push!(a::Automaton{N, W}, name::W) where {N, W} = (push!(states(a), State(name, noedge(a))); push!(stateslengths(a), length(name)); a)
-Base.empty!(a::Automaton{N, W}) where{N, W} = (empty!(states(a)); empty!(stateslengths(a)); push!(a, W()); a)
+Base.push!(a::Automaton{N, W}, name::W) where {N, W} =
+    (push!(states(a), State(name, noedge(a))); push!(stateslengths(a), length(name)); a)
+Base.empty!(a::Automaton{N, W}) where{N, W} =
+    (empty!(states(a)); empty!(stateslengths(a)); push!(a, one(W)); a)
 
 """
     replace(k::NTuple{N, T}, val::T, idx::Integer) where {N, T}

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -256,14 +256,9 @@ end
 ###########################################
 # Ad index automata
 
-"""
-    makeindexautomaton!(a::Automaton, rws::RewritingSystem, abt::Alphabet)
-Takes a given empty automaton (i.e. containing only initial state corresponding
-to empty word) and transforms it into index automaton corresponding to a given
-rewriting system.
-"""
-function makeindexautomaton!(a::Automaton, rws::RewritingSystem, abt::Alphabet=alphabet(ordering(rws)))
-    # a = Automaton(abt)
+function makeindexautomaton!(a::Automaton, rws::RewritingSystem)
+    @assert alphabet(a) == alphabet(rws)
+    empty!(a)
     # Determining simple paths
     for (idx, (lhs, rhs)) in enumerate(rules(rws))
         isactive(rws, idx) || continue
@@ -316,10 +311,7 @@ makeindexautomaton(rws::RewritingSystem) =
     updateautomaton!(a::Automaton, rws::RewritingSystem)
 Updates given automaton so it corresponds to a given rewriting system.
 """
-function updateautomaton!(a::Automaton, rws::RewritingSystem)
-    empty!(a)
-    makeindexautomaton!(a, rws)
-end
+updateautomaton!(a::Automaton, rws::RewritingSystem) = makeindexautomaton!(a, rws)
 
 """
     rewrite_from_left!(v::AbstractWord, w::AbstractWord, a::Automaton)

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -3,58 +3,50 @@
 
 """
     AbstractState{N, W}
-Abstract type representing state of the (index) automaton.
+Abstract type representing state of the (index) automaton over an alphabet of `N` letters.
 
 The subtypes of `AbstractState{N, W}` should implement the following methods which
 constitute `AbstractState` interface:
- * `name`: gives external name of the state
- * `isterminal`: returns whether the state is terminal or not (i.e. whether the
+ * `name`: external name of the state
+ * `isterminal`: predicate to determine if state is terminal (i.e. whether the
     state represents left-hand side of some rewriting rule)
- * `rightrule`: gives the right-hand side of the rewriting rule (for terminal
-    states) or Nothing (for non-terminal states)
- * `inedges`: gives the vector (indexed by position of the letter in the alphabet)
-    of states from which there is an edge entering given state and labelled by
-    the given letter
- * `outedges`: gives the vector (indexed by position of the letter in the alphabet)
-    of states to which there is an edge starting at given state and labelled by
-    the given letter
- * `isnoedge`: returns whether the state represents lack of edge or not
- * `Base.length`: gives the length of the signature of the shortest path to the
+ * `rightrule`: if state is terminal, returns the right-hand side of the rewriting rule.
+ Undefined in other cases.
+ * `inedges`: container (indexed by letters of `AbstractWord`) of source states of in-edges.
+ * `outedges`: container (indexed by letters of `AbstractWord`) of destination states of out-edges.
+ * `isfailstate`: predicate to determine if state represents "fail" state.
+ * `Base.length`: the length of the signature of the shortest path to the
     state, which starts at initial state (length of "simple path")
 """
 abstract type AbstractState{N, W} end
 
 """
     State{N, W<:AbstractWord} <: AbstractState{N, W}
-State as a name (corresponding to the signature of the simple path ending at this
-state), indication whether it is terminal (in which case there is a right-hand part
-of the rewriting rule, vector of states (indexed by the position of the letter in
-the alphabet) from which there is an edge (labelled by letter indexed) to this state
-and vector of states (indexed by position of the letter in the alphabet) to which
-there is an edge (labelled by letter indexed) from this state.
+State of an index automaton over an alphabet of `N` letters.
 """
 mutable struct State{N, W<:AbstractWord} <: AbstractState{N, W}
     name::W
     terminal::Bool
+    failstate::Bool
     rrule::W
     ined::Vector{State{N, W}}
     outed::NTuple{N, State{N, W}}
-    representsnoedge::Bool
 
     function State{N, W}() where {N, W<:AbstractWord}
-        x = new()
-        x.representsnoedge = true
+        x = new{N, W}()
+        x.failstate = true
         return x
     end
 
-    function State(name::W, noedge::State{N, W}) where {N, W}
-        s = State{N, W}()
-        s.name = name
-        s.terminal = false
-        s.rrule = one(W)
-        s.ined = typeof(s)[]
-        s.outed = ntuple(i -> noedge, N)
-        s.representsnoedge = false
+    function State(name::W, failstate::State{N, W}) where {N, W}
+        s = new{N, W}(
+            name,
+            false,
+            false,
+            one(W),
+            State{N,W}[],
+            ntuple(i -> failstate, N),
+        )
         return s
     end
 end
@@ -64,7 +56,7 @@ isterminal(s::State) = s.terminal
 rightrule(s::State) = s.rrule
 inedges(s::State) = s.ined
 outedges(s::State) = s.outed
-isnoedge(s::State) = s.representsnoedge
+isfailstate(s::State) = s.failstate
 Base.length(s::State) = length(name(s))
 
 """
@@ -78,24 +70,24 @@ function declarerightrule!(s::State, w::AbstractWord)
 end
 
 function Base.show(io::IO, s::State)
-    if isnoedge(s)
-        println("Unintialized state")
+    if isfailstate(s)
+        print(io, "Fail state")
     elseif isterminal(s)
         println(io, "Terminal state $(name(s))")
         println(io, "Right rule: $(rightrule(s))")
         println(io, " Edges entering:")
         for (i, e) in enumerate(inedges(s))
-            !isnoedge(e) && println(io, "   ", " - with label $(i) from state $(name(e))")
+            !isfailstate(e) && println(io, "   ", " - with label $(i) from state $(name(e))")
         end
     else
         println(io, "State $(name(s))")
         println(io, " Edges entering:")
         for (i, fromst) in enumerate(inedges(s))
-            !isnoedge(fromst) && println(io, "   ", " - with label $(i) from state $(name(fromst))")
+            !isfailstate(fromst) && println(io, "   ", " - with label $(i) from state $(name(fromst))")
         end
         println(io, " Edges leaving:")
         for (i, tost) in enumerate(outedges(s))
-            !isnoedge(tost) && println(io, "   ", " - with label $(i) from state $(name(tost))")
+            !isfailstate(tost) && println(io, "   ", " - with label $(i) from state $(name(tost))")
         end
     end
 end
@@ -127,7 +119,7 @@ Automaton as a vector of states together with alphabet.
 struct Automaton{N, W<:AbstractWord} <: AbstractAutomaton{N, W}
     states::Vector{State{N, W}}
     abt::Alphabet
-    uniquenoedge::State{N, W}
+    failstate::State{N, W}
     stateslengths::Vector{Int}
     _past_states::Vector{State{N, W}}
 end
@@ -135,14 +127,14 @@ end
 # Default type is set to UInt16
 function Automaton(abt::Alphabet, W::Type{<:AbstractWord}=Word{UInt16})
     S = State{length(abt), W}
-    uniquenoedge = S()
-    Automaton{length(abt), W}([State(one(W), uniquenoedge)], abt, uniquenoedge, [0], S[])
+    failstate = S()
+    Automaton{length(abt), W}([State(one(W), failstate)], abt, failstate, [0], S[])
 end
 
 alphabet(a::Automaton) = a.abt
 states(a::Automaton) = a.states
 initialstate(a::Automaton) = first(states(a))
-noedge(a::Automaton) = a.uniquenoedge
+failstate(a::Automaton) = a.failstate
 stateslengths(a::Automaton) = a.stateslengths
 
 function Base.isempty(a::Automaton)
@@ -152,7 +144,7 @@ function Base.isempty(a::Automaton)
 end
 
 Base.push!(a::Automaton{N, W}, name::W) where {N, W} =
-    (push!(states(a), State(name, noedge(a))); push!(stateslengths(a), length(name)); a)
+    (push!(states(a), State(name, failstate(a))); push!(stateslengths(a), length(name)); a)
 Base.empty!(a::Automaton{N, W}) where{N, W} =
     (empty!(states(a)); empty!(stateslengths(a)); push!(a, one(W)); a)
 
@@ -213,7 +205,7 @@ Base.@propagate_inbounds function removeedge!(a::Automaton{N}, label::Integer, f
     @boundscheck checkbounds(states(a), to)
     @inbounds fromstate = states(a)[from]
     @inbounds tostate = states(a)[to]
-    @inbounds updateoutedges!(fromstate, noedge(a), label)
+    @inbounds updateoutedges!(fromstate, failstate(a), label)
     deleteat!(inedges(tostate), findfirst(isequal(fromstate), inedges(tostate)))
 end
 
@@ -222,10 +214,10 @@ Base.@propagate_inbounds function Base.deleteat!(a::Automaton, idx::Integer)
     @boundscheck checkbounds(stateslengths(a), idx)
     @inbounds state = states(a)[idx]
     for σ in outedges(state)
-        isnoedge(σ) || deleteat!(inedges(σ), findfirst(isequal(state), inedges(σ)))
+        isfailstate(σ) || deleteat!(inedges(σ), findfirst(isequal(state), inedges(σ)))
     end
     for σ in inedges(state)
-        updateoutedges!(σ, noedge(a), findfirst(isequal(state), outedges(σ)))
+        updateoutedges!(σ, failstate(a), findfirst(isequal(state), outedges(σ)))
     end
     @inbounds deleteat!(states(a), idx)
     @inbounds deleteat!(stateslengths(a), idx)
@@ -244,7 +236,7 @@ function walk(a::AbstractAutomaton, sig::AbstractWord, state=first(states(a)))
     idx = 0
     for (i, k) in enumerate(sig)
         next = outedges(state)[k]
-        isnoedge(next) ? break : (idx, state) = (i, next)
+        isfailstate(next) ? break : (idx, state) = (i, next)
     end
     return (idx, state)
 end
@@ -255,7 +247,7 @@ function Base.show(io::IO, a::AbstractAutomaton)
         println(io, " $i. Edges leaving state (", string_repr(name(state), alphabet(a)), "):")
 
         for (i, tostate) in enumerate(outedges(state))
-            !isnoedge(tostate) && println(io,
+            !isfailstate(tostate) && println(io,
                 "   ", " - with label ", alphabet(a)[i], " to state (", string_repr(name(tostate), alphabet(a)), ")")
         end
     end
@@ -277,15 +269,13 @@ function makeindexautomaton!(a::Automaton, rws::RewritingSystem, abt::Alphabet=a
         isactive(rws, idx) || continue
         σ = initialstate(a)
         for (i, letter) in enumerate(lhs)
-            if !isnoedge(outedges(σ)[letter])
-                σ = outedges(σ)[letter]
-            else
+            if isfailstate(outedges(σ)[letter])
                 push!(a, lhs[1:i])
-                addedge!(a, letter, σ, states(a)[end])
-                σ = states(a)[end]
+                addedge!(a, letter, σ, last(states(a)))
             end
+            σ = outedges(σ)[letter]
         end
-        terminal = states(a)[end]
+        terminal = last(states(a))
         declarerightrule!(terminal, rhs)
         # Add loops for terminal state
         for i in 1:length(outedges(terminal))
@@ -294,7 +284,7 @@ function makeindexautomaton!(a::Automaton, rws::RewritingSystem, abt::Alphabet=a
     end
     # Determining cross paths
     for (i, state) in enumerate(outedges(initialstate(a)))
-        isnoedge(state) && addedge!(a, i, 1, 1)
+        isfailstate(state) && addedge!(a, i, 1, 1)
     end
     i = 1
     indcs = findall(isequal(i), stateslengths(a))
@@ -303,7 +293,7 @@ function makeindexautomaton!(a::Automaton, rws::RewritingSystem, abt::Alphabet=a
             σ = states(a)[idx]
             τ = walk(a, @view(name(σ)[2:end]))[2]
             for (letter, state) in enumerate(outedges(σ))
-                isnoedge(state) && addedge!(a, letter, σ, outedges(τ)[letter])
+                isfailstate(state) && addedge!(a, letter, σ, outedges(τ)[letter])
             end
         end
         i += 1

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -316,13 +316,11 @@ function makeindexautomaton!(a::Automaton, rws::RewritingSystem, abt::Alphabet=a
 end
 
 """
-    makeindexautomaton(a::Automaton, rws::RewritingSystem, abt::Alphabet)
+    makeindexautomaton(rws::RewritingSystem, abt::Alphabet)
 Creates index automaton corresponding to a given rewriting system.
 """
-function makeindexautomaton(rws::RewritingSystem, abt::Alphabet=alphabet(ordering(rws)))
-    a = Automaton(abt)
-    return makeindexautomaton!(a, rws, abt)
-end
+makeindexautomaton(rws::RewritingSystem) =
+    (a = Automaton(alphabet(rws)); makeindexautomaton!(a, rws))
 
 """
     updateautomaton!(a::Automaton, rws::RewritingSystem)

--- a/src/automata_kbs2.jl
+++ b/src/automata_kbs2.jl
@@ -75,7 +75,7 @@ function knuthbendix2automaton!(rws::RewritingSystem{W},
     o::Ordering = ordering(rws); maxrules::Integer = 100) where {W<:AbstractWord}
     stack = copy(rules(rws)[active(rws)])
     rws = empty!(rws)
-    at = Automaton(alphabet(o))
+    at = Automaton(alphabet(rws))
     T = eltype(W)
     work = kbWork{T}(1, 0)
     deriverule!(rws, at, stack, work)

--- a/src/bufferwords.jl
+++ b/src/bufferwords.jl
@@ -18,7 +18,7 @@ mutable struct BufferWord{T} <: AbstractWord{T}
         return bw
     end
 
-    function BufferWord{T}(freeatbeg=8, freeatend=8) where T
+    function BufferWord{T}(freeatbeg, freeatend) where T
         l = freeatbeg + freeatend
         return new{T}(Vector{T}(undef, l), freeatbeg+1, freeatbeg)
     end
@@ -26,8 +26,6 @@ end
 
 BufferWord(v::Union{<:Vector{<:Integer},<:AbstractVector{<:Integer}}) =
     BufferWord{UInt16}(v)
-BufferWord(sizehint::Integer = 16) =
-    (l = max(sizehint ÷ 2, 8); BufferWord{UInt16}(l, l))
 
 # helper functions for growing storage:
 
@@ -90,6 +88,7 @@ function Base.pop!(bw::BufferWord)
 end
 
 function Base.popfirst!(bw::BufferWord)
+    @assert !isempty(bw)
     @inbounds val = bw[1]
     bw.lidx +=1
     return val
@@ -145,12 +144,11 @@ function Base.resize!(bw::BufferWord, nl::Integer)
     return bw
 end
 
-function Base.:*(bw::BufferWord, bv::BufferWord)
-    res = BufferWord(bw.lidx-1+
-        length(bw)+
-        length(bv)+
-        internal_length(bv) -
-        bv.ridx)
+function Base.:*(bw::BufferWord{S}, bv::BufferWord{T}) where {S, T}
+    res = BufferWord{promote_type(S,T)}(
+        bw.lidx-1+length(bw) + length(bv),
+        internal_length(bv) - bv.ridx
+    )
     res.lidx = bw.lidx
     res.ridx = res.lidx+length(bw)+length(bv)-1
     @inbounds for i in 1:length(bw)
@@ -172,9 +170,8 @@ function Base.empty!(bw::BufferWord)
 end
 
 # performance methods overloaded from AbstractWord:
-
-Base.one(bw::BufferWord{T}) where T = BufferWord{T}(length(bw))
-Base.isone(bw::BufferWord) = isempty(bw.lidx:bw.ridx)
+# one less allocation:
+Base.one(::Type{BufferWord{T}}) where T = BufferWord{T}(8, 8)
 
 # @view constructor
 Base.view(bw::BufferWord, u::UnitRange{Int}) =

--- a/src/kbs2_with_deleting.jl
+++ b/src/kbs2_with_deleting.jl
@@ -10,7 +10,7 @@ struct BufferPair{T} <: AbstractBufferPair{T}
     _wWord::BufferWord{T}
 end
 
-BufferPair{T}() where {T} = BufferPair(BufferWord{T}(), BufferWord{T}())
+BufferPair{T}() where {T} = BufferPair(one(BufferWord{T}), one(BufferWord{T}))
 
 get_v_word(bp::BufferPair) = wrk._vWord
 get_w_word(bp::BufferPair) = wrk._wWord

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -72,6 +72,7 @@ RewritingSystem(rwrules::Vector{Pair{W,W}}, order::O) where {W<:AbstractWord, O<
 active(s::RewritingSystem) = s.act
 rules(s::RewritingSystem) = s.rwrules
 ordering(s::RewritingSystem) = s.order
+alphabet(s::RewritingSystem) = alphabet(ordering(s))
 
 isactive(s::RewritingSystem, i::Integer) = active(s)[i]
 setactive!(s::RewritingSystem, i::Integer) = active(s)[i] = true

--- a/src/words.jl
+++ b/src/words.jl
@@ -18,13 +18,11 @@ struct Word{T} <: AbstractWord{T}
         check && @assert all(x -> x > 0, v) "All entries of a Word must be positive integers"
         return new{T}(v)
     end
-    Word{T}() where T = new{T}(T[])
 end
 
 # setting the default type to UInt16
 Word(x::AbstractVector{<:Integer}) = Word{UInt16}(x)
 Word(w::AbstractWord{T}) where T = Word{T}(w, false)
-Word() = Word{UInt16}()
 
 struct SubWord{T, V<:SubArray{T,1}} <: AbstractWord{T}
     ptrs::V
@@ -64,6 +62,3 @@ Base.:*(w::Union{Word{S}, SubWord{S}}, v::Union{Word{T}, SubWord{T}}) where {S,T
 
 Base.similar(w::Union{Word, SubWord}, ::Type{S}) where {S} = Word{S}(Vector{S}(undef, length(w)), false)
 
-# performance methods overloaded from AbstractWord:
-
-Base.isone(w::Union{Word, SubWord}) = isempty(w.ptrs)

--- a/test/abstract_words.jl
+++ b/test/abstract_words.jl
@@ -6,9 +6,8 @@ function abstract_word_constructors_test(::Type{Wo}) where Wo
         @test Wo([1,2]) isa KnuthBendix.AbstractWord
         @test Wo{Int}([1,2]) isa Wo{Int}
 
-        @test Wo() isa Wo
-        @test Wo{Int}() isa KnuthBendix.AbstractWord{Int}
-        @test Wo{Int}() isa Wo{Int}
+        @test one(Wo{Int}) isa KnuthBendix.AbstractWord{Int}
+        @test one(Wo{Int}) isa Wo{Int}
 
         @test similar(Wo([1,2])) isa Wo
 
@@ -21,7 +20,7 @@ function abstract_word_basic_functions_test(::Type{Wo}) where Wo
 
     @testset "basic functionality: $Wo" begin
         @test one(Wo{Int}) isa Wo
-        @test one(Wo()) isa Wo
+        @test one(Wo{UInt16}) isa Wo
 
         w = Wo([1,2])
         W = Word{Int}([1,2])
@@ -49,10 +48,10 @@ end
 function abstract_word_push_pop_append_test(::Type{Wo}) where Wo
 
     @testset "push!,pop!,append!,prepend!: $Wo" begin
-        w = Wo(); W = deepcopy(w);
+        w = one(Wo{UInt16}); W = deepcopy(w);
 
         @test push!(w, 1) == Wo([1])
-        @test w == Wo([1]) && W == Wo()
+        @test w == Wo([1]) && isone(W)
         W = deepcopy(w)
 
         @test append!(w, [1,2]) == Wo([1,1,2])

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -67,7 +67,7 @@
 
     lenlexord = KnuthBendix.LenLex(A)
     rsc = KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, be=>eb, pa=>ap, pe=>ep], lenlexord)
-    ia = KnuthBendix.makeindexautomaton(rsc, A)
+    ia = KnuthBendix.makeindexautomaton(rsc)
 
     testword = Word([1,1,1,1,1,2,2,2,3,4,2,2,3,3,3,4,4,4,4,3,4,3,4,1,2,1,1,1,1,1,1,1,2,1,3,4])
     @test KnuthBendix.rewrite_from_left(testword, rsc) == KnuthBendix.rewrite_from_left(testword, ia)
@@ -79,6 +79,6 @@
     @test isempty(empty!(ia))
 
     rsd = KnuthBendix.RewritingSystem([a=>ε, b=>ε], lenlexord)
-    iad = KnuthBendix.makeindexautomaton(rsd, A)
+    iad = KnuthBendix.makeindexautomaton(rsd)
     @test KnuthBendix.rewrite_from_left(testword, rsd) == KnuthBendix.rewrite_from_left(testword, iad)
 end

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -45,7 +45,7 @@
     deleteat!(ta, 2)
     @test length(KnuthBendix.states(ta)) == 1
     @test length(KnuthBendix.stateslengths(ta)) == 1
-    @test KnuthBendix.isnoedge(KnuthBendix.outedges(σ)[1])
+    @test KnuthBendix.isfailstate(KnuthBendix.outedges(σ)[1])
 
     A = KnuthBendix.Alphabet(['a', 'e', 'b', 'p'])
     KnuthBendix.set_inversion!(A, 'a', 'e')

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -14,9 +14,9 @@
     @test σ isa KnuthBendix.State
     @test σ isa KnuthBendix.State{4, Word{UInt16}}
 
-    @test KnuthBendix.name(σ) == Word(Int[])
+    @test isone(KnuthBendix.name(σ))
     @test !KnuthBendix.isterminal(σ)
-    @test KnuthBendix.rightrule(σ) == Word()
+    @test isone(KnuthBendix.rightrule(σ))
 
     @test length(KnuthBendix.states(ta)) == 1
     @test length(KnuthBendix.inedges(σ)) == 0
@@ -24,14 +24,14 @@
     @test length(KnuthBendix.stateslengths(ta)) == 1
     @test length(σ) == 0
 
-    KnuthBendix.declarerightrule!(σ, Word())
+    KnuthBendix.declarerightrule!(σ, one(KnuthBendix.name(σ)))
     @test KnuthBendix.isterminal(σ)
-    @test KnuthBendix.rightrule(σ) == Word()
+    @test isone(KnuthBendix.rightrule(σ))
 
-    push!(ta, KnuthBendix.Word([1]))
+    push!(ta, Word([1]))
     KnuthBendix.addedge!(ta, 1, 1, 2)
     @test length(KnuthBendix.inedges(KnuthBendix.states(ta)[2])) == 1
-    @test KnuthBendix.walk(ta, KnuthBendix.Word([1])) == (1, KnuthBendix.states(ta)[2])
+    @test KnuthBendix.walk(ta, Word([1])) == (1, KnuthBendix.states(ta)[2])
     @test_throws BoundsError KnuthBendix.addedge!(ta, 5, 1, 2)
     @test_throws BoundsError KnuthBendix.addedge!(ta, 1, 3, 2)
     @test_throws BoundsError KnuthBendix.addedge!(ta, 1, 1, 3)
@@ -39,7 +39,7 @@
     @test_throws BoundsError KnuthBendix.removeedge!(ta, 1, 3, 2)
     @test_throws BoundsError KnuthBendix.removeedge!(ta, 1, 1, 3)
     KnuthBendix.removeedge!(ta, 1, 1, 2)
-    @test KnuthBendix.walk(ta, KnuthBendix.Word([1])) == (0, KnuthBendix.states(ta)[1])
+    @test KnuthBendix.walk(ta, Word([1])) == (0, KnuthBendix.states(ta)[1])
 
     KnuthBendix.addedge!(ta, 1, 1, 2)
     deleteat!(ta, 2)
@@ -51,28 +51,28 @@
     KnuthBendix.set_inversion!(A, 'a', 'e')
     KnuthBendix.set_inversion!(A, 'b', 'p')
 
-    a = KnuthBendix.Word([1,2])
-    b = KnuthBendix.Word([2,1])
-    c = KnuthBendix.Word([3,4])
-    d = KnuthBendix.Word([4,3])
-    ε = KnuthBendix.Word()
-    ba = KnuthBendix.Word([3,1])
-    ab = KnuthBendix.Word([1,3])
-    be = KnuthBendix.Word([3,2])
-    eb = KnuthBendix.Word([2,3])
-    pa = KnuthBendix.Word([4,1])
-    ap = KnuthBendix.Word([1,4])
-    pe = KnuthBendix.Word([4,2])
-    ep = KnuthBendix.Word([2,4])
+    a = Word([1,2])
+    b = Word([2,1])
+    c = Word([3,4])
+    d = Word([4,3])
+    ε = one(a)
+    ba = Word([3,1])
+    ab = Word([1,3])
+    be = Word([3,2])
+    eb = Word([2,3])
+    pa = Word([4,1])
+    ap = Word([1,4])
+    pe = Word([4,2])
+    ep = Word([2,4])
 
     lenlexord = KnuthBendix.LenLex(A)
     rsc = KnuthBendix.RewritingSystem([a=>ε, b=>ε, c=>ε, d=>ε, ba=>ab, be=>eb, pa=>ap, pe=>ep], lenlexord)
     ia = KnuthBendix.makeindexautomaton(rsc, A)
 
-    testword = KnuthBendix.Word([1,1,1,1,1,2,2,2,3,4,2,2,3,3,3,4,4,4,4,3,4,3,4,1,2,1,1,1,1,1,1,1,2,1,3,4])
+    testword = Word([1,1,1,1,1,2,2,2,3,4,2,2,3,3,3,4,4,4,4,3,4,3,4,1,2,1,1,1,1,1,1,1,2,1,3,4])
     @test KnuthBendix.rewrite_from_left(testword, rsc) == KnuthBendix.rewrite_from_left(testword, ia)
 
-    w = KnuthBendix.Word([1,3,4,1,4,4,1,1,4,2,3,2,4,2,2,3,1,2,1])
+    w = Word([1,3,4,1,4,4,1,1,4,2,3,2,4,2,2,3,1,2,1])
     @test KnuthBendix.rewrite_from_left(w, rsc) == KnuthBendix.rewrite_from_left(w, ia)
 
     @test !isempty(ia)

--- a/test/automata_kbs2.jl
+++ b/test/automata_kbs2.jl
@@ -8,7 +8,7 @@
     b = Word([2,1])
     c = Word([3,4])
     d = Word([4,3])
-    ε = Word()
+    ε = one(a)
 
     ba = Word([3,1])
     ab = Word([1,3])

--- a/test/bufferwords.jl
+++ b/test/bufferwords.jl
@@ -1,12 +1,12 @@
 import KnuthBendix: KnuthBendix.BufferWord
 
 @testset "KnuthBendix.BufferWord internals" begin
-    @test KnuthBendix.BufferWord() isa KnuthBendix.BufferWord{UInt16}
-    @test isone(KnuthBendix.BufferWord())
+    @test one(KnuthBendix.BufferWord{Int}) isa KnuthBendix.BufferWord{Int}
+    @test isone(one(KnuthBendix.BufferWord{UInt16}))
     @test KnuthBendix.BufferWord([1,2,3]) isa KnuthBendix.BufferWord{UInt16}
     @test !isone(KnuthBendix.BufferWord([1,2,3]))
 
-    let bw = KnuthBendix.BufferWord();
+    let bw = one(KnuthBendix.BufferWord{UInt16});
         append!(bw, [1,2,3,4])
         il = KnuthBendix.internal_length(bw)
         W = Word(bw)
@@ -41,7 +41,7 @@ end
 
 @testset "KnuthBendix.BufferWord push/append" begin
 
-    let bw_orig = KnuthBendix.BufferWord()
+    let bw_orig = one(KnuthBendix.BufferWord{UInt16})
 
         bw = deepcopy(bw_orig)
         @test push!(bw,1) == [1]

--- a/test/kbs2.jl
+++ b/test/kbs2.jl
@@ -8,7 +8,7 @@
     b = Word([2,1])
     c = Word([3,4])
     d = Word([4,3])
-    ε = Word()
+    ε = one(a)
 
     ba = Word([3,1])
     ab = Word([1,3])

--- a/test/kbs2_with_deleting.jl
+++ b/test/kbs2_with_deleting.jl
@@ -8,7 +8,7 @@
     b = Word([2,1])
     c = Word([3,4])
     d = Word([4,3])
-    ε = Word()
+    ε = one(a)
 
     ba = Word([3,1])
     ab = Word([1,3])

--- a/test/orderings.jl
+++ b/test/orderings.jl
@@ -26,13 +26,13 @@
     wo = WreathOrder(A)
     @test wo isa KnuthBendix.WordOrdering
 
-    ε = Word()
     w1 = Word([3,1,4,2,3])
     w5 = Word([1,2,3,2,4,1,2,4])
     w4 = Word([1,3,1,2,4,2,1])
     w6 = Word([1,2,3,2,1,4,2,4])
     w2 = Word([1,3,4,3,2])
     w3 = Word([1,3,2,1,4,1,2])
+    ε = one(w1)
 
     a = [w1, w5, w4, w6, w2, w3, ε]
 

--- a/test/rws_examples.jl
+++ b/test/rws_examples.jl
@@ -3,8 +3,8 @@ function RWS_Example_5_1()
     KnuthBendix.set_inversion!(Al, 'a', 'A')
     KnuthBendix.set_inversion!(Al, 'b', 'B')
 
-    ε = Word()
     a,A,b,B = Word.([i] for i in 1:4)
+    ε = one(a)
 
     R = RewritingSystem([a*A=>ε, A*a=>ε, b*B=>ε, B*b=>ε, b*a=>a*b], LenLex(Al))
 
@@ -18,8 +18,8 @@ function RWS_Example_5_2()
     KnuthBendix.set_inversion!(Al, 'a', 'A')
     KnuthBendix.set_inversion!(Al, 'b', 'B')
 
-    ε = Word()
     a,b,B,A = Word.([i] for i in 1:4)
+    ε = one(a)
 
     R = RewritingSystem([a*A=>ε, A*a=>ε, b*B=>ε, B*b=>ε, b*a=>a*b], LenLex(Al))
 
@@ -31,8 +31,8 @@ RWS_ZxZ_nonterminating() = RWS_Example_5_2()
 function RWS_Example_5_3()
     Al = Alphabet(['a', 'b'])
 
-    ε = Word()
     a,b = Word.([i] for i in 1:2)
+    ε = one(a)
 
     R = RewritingSystem([a^2=>ε, b^3=>ε, (a*b)^3=>ε], LenLex(Al))
 
@@ -43,8 +43,8 @@ function RWS_Example_5_4()
     Al = Alphabet(['a', 'b', 'B'])
     KnuthBendix.set_inversion!(Al, 'b', 'B')
 
-    ε = Word()
     a,b,B = Word.([i] for i in 1:3)
+    ε = one(a)
 
     R = RewritingSystem([a^2=>ε, b*B=>ε, b^3=>ε, (a*b)^3=>ε], LenLex(Al))
 
@@ -57,8 +57,8 @@ function RWS_Example_5_5()
     KnuthBendix.set_inversion!(Al, 'b', 'B')
     KnuthBendix.set_inversion!(Al, 'a', 'A')
 
-    ε = Word()
     c, C, b, B, a, A = Word.([i] for i in 1:6)
+    ε = one(a)
 
     eqns = [a*A=>ε, A*a=>ε, b*B=>ε, B*b=>ε, c*C=>ε, C*c=>ε,
         c*a =>a*c, c*b=>b*c, b*a=>a*b*c]
@@ -71,8 +71,8 @@ function RWS_Example_237_abaB(n)
     Al = Alphabet(['a', 'b', 'B'])
     KnuthBendix.set_inversion!(Al, 'b', 'B')
 
-    ε = Word()
     a, b, B = Word.([i] for i in 1:3)
+    ε = one(a)
 
     eqns = [a^2=>ε, b*B=>ε, b^3=>ε, (a*b)^7=>ε, (a*b*a*B)^n=>ε]
 
@@ -86,8 +86,8 @@ function RWS_Example_6_5()
     Al = Alphabet(['a', 'b', 'B'])
     KnuthBendix.set_inversion!(Al, 'b', 'B')
 
-    ε = Word()
     a, b, B = Word.([i] for i in 1:3)
+    ε = one(a)
     eqns = [a*a=>ε, b*B=>ε, b^2=>B, (B*a)^3*B=>(a*b)^3*a,
         (b*a*B*a)^2 => (a*b*a*B)^2]
 
@@ -110,7 +110,7 @@ function RWS_Closed_Orientable_Surface(n)
         KnuthBendix.set_inversion!(Al, "b" * subscript, "B" * subscript)
     end
 
-    ε = Word()
+    ε = one(Word{UInt16})
     rules = Pair{typeof(ε), typeof(ε)}[]
     word = Int[]
 
@@ -142,7 +142,7 @@ end
     rws = KnuthBendix.knuthbendix1(R)
     @test length(rws) == 6
     a,b = Word.([i] for i in 1:2)
-    ε = Word()
+    ε = one(a)
     @test KnuthBendix.rules(rws) == [a^2=>ε, b^3=>ε,
         (b*a)^2=>a*b^2, (a*b)^2=>b^2*a, a*b^2*a=>b*a*b, b^2*a*b^2=>a*b*a]
 
@@ -182,7 +182,7 @@ end
     rws = KnuthBendix.knuthbendix2(R)
     @test length(rws) == 6
     a,b = Word.([i] for i in 1:2)
-    ε = Word()
+    ε = one(a)
     @test Set(KnuthBendix.rules(rws)) == Set([a^2=>ε, b^3=>ε,
         (b*a)^2=>a*b^2, a*b^2*a=>b*a*b, b^2*a*b^2=>a*b*a, (a*b)^2=>b^2*a])
 

--- a/test/words.jl
+++ b/test/words.jl
@@ -3,8 +3,8 @@
     @test Word(Int[]) isa KnuthBendix.AbstractWord
     @test Word(Int[]) isa Word
     @test Word(Int[]) isa Word{UInt16}
-    @test Word() isa Word{UInt16}
-    @test Word{Int}() isa Word{Int}
+    @test one(Word{UInt16}) isa Word{UInt16}
+    @test one(Word{Int}) isa Word{Int}
 
     w = Word([1, 2])
     W = Word{Int}([1, 2])
@@ -61,9 +61,9 @@
     @test u2 == Word([1])
     @test popfirst!(u3) == 4
     @test u3 == u1
-    
+
     @test string(Word([1,2])) == "Word{UInt16}: 1·2"
-    @test string(Word()) == "Word{UInt16}: (empty word)"
+    @test string(one(Word{UInt16})) == "Word{UInt16}: (empty word)"
 end
 
 @testset "SubWords" begin


### PR DESCRIPTION
initially I was only to replace `W()` by `one(W)`, but then I got carried away...

btw. after spending some time poking in automata I really like the design; I allowed myself to change `noedge` etc. to `failstate` to be closer to nomenclature in the literature.