### PR TITLE
Mk/rebuild idx a

### DIFF
--- a/src/KnuthBendix.jl
+++ b/src/KnuthBendix.jl
@@ -16,6 +16,8 @@ include("rules.jl")
 
 include("rewriting.jl")
 include("automata.jl")
+include("index_automaton.jl")
+include("rebuilding_idxA.jl")
 include("helper_structures.jl")
 include("derive_rule.jl")
 include("force_confluence.jl")

--- a/src/abstract_words.jl
+++ b/src/abstract_words.jl
@@ -6,7 +6,7 @@ Abstract type representing words over an Alphabet.
 contex of an Alphabet (when integers are understood as pointers to letters).
 The subtypes of `AbstractWord{T}` need to implement the following methods which
 constitute `AbstractWord` interface:
- * a constructor from `AbstractVector{T}`
+ * a constructor from `AbstractVector{T}` with `check` optional argument (`true` implies checking the validity of input),
  * linear indexing (1-based) consistent with iteration returning pointers to letters of an alphabet (`getindex`, `setindex`, `size`),
  * `Base.push!`/`Base.pushfirst!`: append a single value at the end/beginning,
  * `Base.pop!`/`Base.popfirst!`: pop a single value from the end/beginning,

--- a/src/abstract_words.jl
+++ b/src/abstract_words.jl
@@ -47,7 +47,7 @@ end
     return length(w) == length(v) && all(w[i] == v[i] for i in eachindex(w))
 end
 
-Base.convert(::Type{W}, w::AbstractWord) where {W<:AbstractWord} = W(w)
+Base.convert(::Type{W}, w::AbstractWord) where {W<:AbstractWord} = W(w, false)
 Base.convert(::Type{W}, w::W) where {W<:AbstractWord} = w
 
 # resize + copyto!
@@ -67,12 +67,12 @@ function Base.:*(w::AbstractWord, v::AbstractWord)
     return out
 end
 
-Base.one(::Type{W}) where {W<:AbstractWord} = W(eltype(W)[])
+Base.one(::Type{W}) where {W<:AbstractWord} = W(eltype(W)[], false)
 Base.one(::W) where {W<:AbstractWord} = one(W)
 Base.isone(w::AbstractWord) = iszero(length(w))
 
 function Base.getindex(w::W, u::AbstractRange) where {W<:AbstractWord}
-    return W([w[i] for i in u])
+    return W([w[i] for i in u], false)
 end
 
 Base.view(w::AbstractWord, u::AbstractRange) = w[u] # general fallback

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -14,9 +14,10 @@ mutable struct State{I,D,V}
 end
 
 function State{I,D,V}(id, data; max_degree::Integer) where {I,D,V}
-    s = State{I,D,V}(Vector{State{I,D,V}}(undef, max_degree), id)
-    s.data = data
-    return s
+    S = State{I,D,V}
+    st = S(Vector{S}(undef, max_degree), id)
+    st.data = data
+    return st
 end
 
 isfail(s::State) = !isdefined(s, :transitions)

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -23,24 +23,19 @@ end
 isfail(s::State) = !isdefined(s, :transitions)
 isterminal(s::State) = isdefined(s, :value)
 id(s::State) = s.id
+value(s::State) = s.value
+setvalue!(s::State, v) = s.value = v
 
 function hasedge(s::State, i::Integer)
     return isassigned(s.transitions, i) && !isfail(s.transitions[i])
 end
 
 function Base.getindex(s::State, i::Integer)
-    !hasedge(s, i) && return nothing
-    return s.transitions[i]
-end
-function Base.setindex!(s::State, v::State, i::Integer)
-    return s.transitions[i] = v
+    hasedge(s, i) && return s.transitions[i]
+    return nothing
 end
 
-function value(s::State)
-    isterminal(s) && return s.value
-    return throw("state is not terminal and its value is not assigned")
-end
-setvalue!(s::State, v) = s.value = v
+Base.setindex!(s::State, v::State, i::Integer) = s.transitions[i] = v
 
 max_degree(s::State) = length(s.transitions)
 degree(s::State) = count(i -> hasedge(s, i), 1:max_degree(s))

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -80,21 +80,31 @@ end
 ###########################################
 # Automata
 
-abstract type Automaton end
+"""
+    Automaton{S} aka. DFA
+Struct for deterministic finite automata (DFA) with states of type `S`.
+"""
+abstract type Automaton{S} end
+
+"""
+    initial(A::Automaton)
+Return the initial state of a (deterministic) automaton.
+"""
+function initial(::Automaton) end
 
 """
 	hasedge(A::Automaton, σ, label)
 Check if `A` contains an edge starting at `σ` labeled by `label`
 """
-function hasedge(A::Automaton, σ, label) end
+function hasedge(at::Automaton{S}, σ::S, label) where {S} end
 
-function addedge!(A::Automaton, src::S, dst::S, label) where {S} end
+function addedge!(at::Automaton{S}, src::S, dst::S, label) where {S} end
 
 """
 	trace(label, A::Automaton, σ)
 Return `τ` if `(σ, label, τ)` is in `A`, otherwise return nothing.
 """
-function trace(label, A::Automaton, σ) end
+function trace(label, A::Automaton{S}, σ::S) where {S} end
 
 """
 	trace(w::AbstractVector{<:Integer}, A::Automaton[, σ=initial(A)])
@@ -102,13 +112,15 @@ Return a pair `(l, τ)`, where
  * `l` is the length of the longest prefix of `w` which defines a path starting at `σ` in `A` and
  * `τ` is the last state (node) on the path.
 """
-@inline function trace(w::AbstractVector, A::Automaton, σ = initial(A))
+@inline function trace(
+    w::AbstractVector,
+    A::Automaton{S},
+    σ::S = initial(A),
+) where {S}
     for (i, l) in enumerate(w)
-        if hasedge(A, σ, l)
-            σ = trace(l, A, σ)
-        else
-            return i - 1, σ
-        end
+        τ = trace(l, A, σ)
+        isnothing(τ) && return i - 1, σ
+        σ = τ
     end
     return length(w), σ
 end

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -2,13 +2,14 @@
 
 mutable struct State{I,D,V}
     transitions::Vector{State{I,D,V}}
+    uptodate::Bool
     id::I
     data::D
     value::V
 
     State{I,D,V}() where {I,D,V} = new{I,D,V}()
     function State{I,D,V}(transitions::AbstractVector, id) where {I,D,V}
-        return new{I,D,V}(transitions, id)
+        return new{I,D,V}(transitions, true, id)
     end
 end
 
@@ -22,7 +23,9 @@ isfail(s::State) = !isdefined(s, :transitions)
 isterminal(s::State) = isdefined(s, :value)
 id(s::State) = s.id
 
-hasedge(s::State, i::Integer) = isassigned(s.transitions, i) && !isfail(s.transitions[i])
+function hasedge(s::State, i::Integer)
+    return isassigned(s.transitions, i) && !isfail(s.transitions[i])
+end
 
 function Base.getindex(s::State, i::Integer)
     !hasedge(s, i) && return nothing
@@ -107,156 +110,4 @@ Return a pair `(l, τ)`, where
         end
     end
     return length(w), σ
-end
-
-## particular implementation of Index Automaton
-
-mutable struct IndexAutomaton{S,V} <: Automaton
-    initial::S
-    states::V
-    _path::Vector{S}
-end
-
-initial(idxA::IndexAutomaton) = idxA.initial
-
-hasedge(idxA::IndexAutomaton, σ::State, label::Integer) = hasedge(σ, label)
-addedge!(idxA::IndexAutomaton, src::State, dst::State, label) = src[label] = dst
-
-Base.isempty(idxA::Automaton) = degree(initial(idxA)) == 0
-
-word_type(::IndexAutomaton{<:State{S,D,V}}) where {S,D,V} = eltype(V)
-
-trace(label::Integer, idxA::IndexAutomaton, σ::State) = σ[label]
-
-function IndexAutomaton(R::RewritingSystem{W}) where {W}
-    id = @view one(W)[1:0]
-    # id = one(W)
-    α = State{typeof(id),UInt32,eltype(rules(R))}(
-        id,
-        0,
-        max_degree = length(alphabet(R)),
-    )
-
-    indexA = IndexAutomaton(α, Vector{typeof(α)}[], [α])
-    append!(indexA, rules(R))
-
-    return indexA
-end
-
-function Base.append!(idxA::IndexAutomaton, rwrules)
-    # isempty(rwrules) && return idxA
-    idxA = direct_edges!(idxA, rwrules)
-    idxA = skew_edges!(idxA)
-    return idxA
-end
-
-function addstate!(idxA::IndexAutomaton, σ::State)
-    radius = length(id(σ))
-    ls = length(idxA.states)
-    if ls < radius
-        T = eltype(idxA.states)
-        resize!(idxA.states, radius)
-        for i in ls+1:radius
-            idxA.states[i] = Vector{T}[]
-        end
-    end
-    return push!(idxA.states[radius], σ)
-end
-
-function direct_edges!(idxA::IndexAutomaton, rwrules)
-    α = initial(idxA)
-    S = typeof(α)
-    n = max_degree(α)
-    for rule in rwrules
-        lhs, _ = rule
-        σ = α
-        α.data += 1
-        for (radius, letter) in enumerate(lhs)
-            if !hasedge(idxA, σ, letter)
-                τ = S(@view(lhs[1:radius]), 0, max_degree = n)
-                addstate!(idxA, τ)
-                addedge!(idxA, σ, τ, letter)
-            end
-            @assert id(σ[letter]) == @view lhs[1:radius]
-
-            σ = σ[letter]
-            σ.data += 1
-        end
-        setvalue!(σ, rule)
-    end
-    return idxA
-end
-
-function skew_edges!(idxA::IndexAutomaton)
-    # add missing loops at the root (start of the induction)
-    α = initial(idxA)
-    if !iscomplete(α)
-        for x in 1:max_degree(α)
-            if !hasedge(idxA, α, x)
-                addedge!(idxA, α, α, x)
-            end
-        end
-    end
-
-    # this has to be done in breadth-first fashion
-    # to ensure that trace(U, idxA) is successful
-    for states in idxA.states
-        for σ in states # states of particular radius
-            iscomplete(σ) && continue
-
-            τ = let U = @view id(σ)[2:end]
-                l, τ = trace(U, idxA) # we're tracing a shorter word, so...
-                @assert l == length(U) # the whole U defines a path in A and
-                @assert iscomplete(τ) # (by the induction step)
-                τ
-            end
-
-            for label in 1:max_degree(σ)
-                hasedge(idxA, σ, label) && continue
-                addedge!(idxA, σ, τ[label], label)
-            end
-        end
-    end
-    return idxA
-end
-
-function rewrite_from_left!(
-    v::AbstractWord,
-    w::AbstractWord,
-    idxA::IndexAutomaton;
-    path = idxA._path,
-)
-    resize!(path, 1)
-    path[1] = initial(idxA)
-
-    resize!(v, 0)
-    sizehint!(path, length(w))
-    while !isone(w)
-        x = popfirst!(w)
-        σ = path[end] # current state
-        τ = σ[x] # next state
-        @assert !isnothing(τ) "ia doesn't seem to be complete!; $σ"
-
-        if isterminal(τ)
-            lhs, rhs = value(τ)
-            # lhs is a suffix of v·x, so we delete it from v
-            resize!(v, length(v) - length(lhs) + 1)
-            # and prepend rhs to w
-            prepend!(w, rhs)
-            # now we need to rewind the path
-            resize!(path, length(path) - length(lhs) + 1)
-            # @assert trace(v, ia) == (length(v), last(path))
-        else
-            push!(v, x)
-            push!(path, τ)
-        end
-    end
-    return v
-end
-
-function rebuild!(idxA::IndexAutomaton, rws::RewritingSystem)
-    at = IndexAutomaton(rws)
-    idxA.initial = at.initial
-    idxA.states = at.states
-    return idxA
 end

--- a/src/bufferwords.jl
+++ b/src/bufferwords.jl
@@ -7,6 +7,7 @@ mutable struct BufferWord{T} <: AbstractWord{T}
         v::AbstractVector{<:Integer},
         freeatbeg = 8,
         freeatend = 8,
+        check = true,
     ) where {T}
         storage = Vector{T}(undef, freeatbeg + length(v) + freeatend)
         bw = new{T}(storage, freeatbeg + 1, freeatbeg + length(v))
@@ -14,6 +15,7 @@ mutable struct BufferWord{T} <: AbstractWord{T}
         # placing content in the middle
         # storage[freeatbeg+1:end-freeatend] .= v
         @inbounds for i in 1:length(v)
+            check && @assert v[i] > 0 "AbstractWords must consist of positive integers"
             bw[i] = v[i]
         end
 

--- a/src/derive_rule.jl
+++ b/src/derive_rule.jl
@@ -32,9 +32,14 @@ end
 # Naive KBS implementation
 ##########################
 
-@inline function _iscritical(u::AbstractWord, v::AbstractWord, rewriting, work::kbWork)
-    a = rewrite_from_left!(work.lhsPair, u, rewriting)
-    b = rewrite_from_left!(work.rhsPair, v, rewriting)
+@inline function _iscritical(
+    u::AbstractWord,
+    v::AbstractWord,
+    rewriting,
+    work::Workspace,
+)
+    a = rewrite_from_left!(work.iscritical_1p, u, rewriting)
+    b = rewrite_from_left!(work.iscritical_2p, v, rewriting)
     return a ≠ b, (a, b)
 end
 
@@ -50,7 +55,7 @@ follow from the added new rules). See [Sims, p. 76].
 function deriverule!(
     rws::RewritingSystem{W},
     stack,
-    work::kbWork,
+    work::Workspace,
     o::Ordering = ordering(rws),
 ) where {W}
     while !isempty(stack)
@@ -68,7 +73,7 @@ end
 function deactivate_rules!(
     rws::RewritingSystem,
     stack,
-    work::kbWork,
+    work::Workspace,
     new_rule::Rule,
 )
     for rule in rules(rws)
@@ -78,7 +83,7 @@ function deactivate_rules!(
             deactivate!(rule)
             push!(stack, (first(rule), last(rule)))
         elseif occursin(new_rule.lhs, rhs)
-            new_rhs = rewrite_from_left!(work.rhsPair, rhs, rws)
+            new_rhs = rewrite_from_left!(work.iscritical_1p, rhs, rws)
             update_rhs!(rule, new_rhs)
         end
     end

--- a/src/derive_rule.jl
+++ b/src/derive_rule.jl
@@ -58,7 +58,7 @@ function deriverule!(
         critical, (a, b) = _iscritical(u, v, rws, work)
         if critical
             simplifyrule!(a, b, o)
-            new_rule = Rule{W}(W(a), W(b), o)
+            new_rule = Rule{W}(W(a, false), W(b, false), o)
             push!(rws, new_rule)
             deactivate_rules!(rws, stack, work, new_rule)
         end

--- a/src/force_confluence.jl
+++ b/src/force_confluence.jl
@@ -101,7 +101,7 @@ function find_critical_pairs!(
                 _store!(work, lhs₁[1:end-lb], rhs₂, rhs₁, lhs₂[lb+1:end])
             critical, (a, c) = _iscritical(a_rhs₂, rhs₁_c, rewriting, work)
             # a and c memory is owned by work!
-            critical && push!(stack, (W(a), W(c)))
+            critical && push!(stack, (W(a, false), W(c, false)))
         end
     end
     return stack

--- a/src/index_automaton.jl
+++ b/src/index_automaton.jl
@@ -114,16 +114,16 @@ function rewrite_from_left!(
     v::AbstractWord,
     w::AbstractWord,
     idxA::IndexAutomaton;
-    path = idxA._path,
+    history_tape = idxA._path,
 )
-    resize!(path, 1)
-    path[1] = initial(idxA)
+    resize!(history_tape, 1)
+    history_tape[1] = initial(idxA)
 
     resize!(v, 0)
-    sizehint!(path, length(w))
+    sizehint!(history_tape, length(w))
     while !isone(w)
         x = popfirst!(w)
-        σ = path[end] # current state
+        σ = history_tape[end] # current state
         τ = σ[x] # next state
         @assert !isnothing(τ) "ia doesn't seem to be complete!; $σ"
 
@@ -133,12 +133,12 @@ function rewrite_from_left!(
             resize!(v, length(v) - length(lhs) + 1)
             # and prepend rhs to w
             prepend!(w, rhs)
-            # now we need to rewind the path
-            resize!(path, length(path) - length(lhs) + 1)
+            # now we need to rewind the history tape
+            resize!(history_tape, length(history_tape) - length(lhs) + 1)
             # @assert trace(v, ia) == (length(v), last(path))
         else
             push!(v, x)
-            push!(path, τ)
+            push!(history_tape, τ)
         end
     end
     return v

--- a/src/index_automaton.jl
+++ b/src/index_automaton.jl
@@ -120,7 +120,6 @@ function rewrite_from_left!(
     history_tape[1] = initial(idxA)
 
     resize!(v, 0)
-    sizehint!(history_tape, length(w))
     while !isone(w)
         x = popfirst!(w)
         σ = history_tape[end] # current state

--- a/src/index_automaton.jl
+++ b/src/index_automaton.jl
@@ -1,0 +1,145 @@
+## particular implementation of Index Automaton
+
+mutable struct IndexAutomaton{S,V} <: Automaton
+    initial::S
+    states::V
+    _path::Vector{S}
+end
+
+initial(idxA::IndexAutomaton) = idxA.initial
+
+hasedge(idxA::IndexAutomaton, σ::State, label::Integer) = hasedge(σ, label)
+addedge!(idxA::IndexAutomaton, src::State, dst::State, label) = src[label] = dst
+
+Base.isempty(idxA::Automaton) = degree(initial(idxA)) == 0
+
+word_type(::IndexAutomaton{<:State{S,D,V}}) where {S,D,V} = eltype(V)
+
+trace(label::Integer, idxA::IndexAutomaton, σ::State) = σ[label]
+
+function IndexAutomaton(R::RewritingSystem{W}) where {W}
+    id = @view one(W)[1:0]
+    # id = one(W)
+    α = State{typeof(id),UInt32,eltype(rules(R))}(
+        id,
+        0,
+        max_degree = length(alphabet(R)),
+    )
+
+    idxA = IndexAutomaton(α, Vector{typeof(α)}[], [α])
+    idxA = direct_edges!(idxA, rules(R))
+    idxA = skew_edges!(idxA)
+
+    return idxA
+end
+
+function direct_edges!(idxA::IndexAutomaton, rwrules)
+    for rule in rwrules
+        add_direct_path!(idxA, rule)
+    end
+    return idxA
+end
+
+function add_direct_path!(idxA::IndexAutomaton, rule)
+    α = initial(idxA)
+    S = typeof(α)
+    n = max_degree(α)
+    lhs, _ = rule
+    σ = α
+    α.data += 1
+    for (radius, letter) in enumerate(lhs)
+        if !hasedge(idxA, σ, letter)
+            τ = S(@view(lhs[1:radius]), 0, max_degree = n)
+            addstate!(idxA, τ)
+            addedge!(idxA, σ, τ, letter)
+        end
+        @assert id(σ[letter]) == @view lhs[1:radius]
+
+        σ = σ[letter]
+        σ.data += 1
+    end
+    setvalue!(σ, rule)
+    return idxA
+end
+
+function addstate!(idxA::IndexAutomaton, σ::State)
+    radius = length(id(σ))
+    ls = length(idxA.states)
+    if ls < radius
+        T = eltype(idxA.states)
+        resize!(idxA.states, radius)
+        for i in ls+1:radius
+            idxA.states[i] = Vector{T}[]
+        end
+    end
+    σ.uptodate = true
+    return push!(idxA.states[radius], σ)
+end
+
+function skew_edges!(idxA::IndexAutomaton)
+    # add missing loops at the root (start of the induction)
+    α = initial(idxA)
+    if !iscomplete(α)
+        for x in 1:max_degree(α)
+            if !hasedge(idxA, α, x)
+                addedge!(idxA, α, α, x)
+            end
+        end
+    end
+
+    # this has to be done in breadth-first fashion
+    # to ensure that trace(U, idxA) is successful
+    for states in idxA.states
+        for σ in states # states of particular radius
+            iscomplete(σ) && continue
+            isterminal(σ) && continue
+
+            τ = let U = @view id(σ)[2:end]
+                l, τ = trace(U, idxA) # we're tracing a shorter word, so...
+                @assert l == length(U) # the whole U defines a path in A and
+                @assert iscomplete(τ) # (by the induction step)
+                τ
+            end
+
+            for label in 1:max_degree(σ)
+                hasedge(idxA, σ, label) && continue
+                addedge!(idxA, σ, τ[label], label)
+            end
+        end
+    end
+    return idxA
+end
+
+function rewrite_from_left!(
+    v::AbstractWord,
+    w::AbstractWord,
+    idxA::IndexAutomaton;
+    path = idxA._path,
+)
+    resize!(path, 1)
+    path[1] = initial(idxA)
+
+    resize!(v, 0)
+    sizehint!(path, length(w))
+    while !isone(w)
+        x = popfirst!(w)
+        σ = path[end] # current state
+        τ = σ[x] # next state
+        @assert !isnothing(τ) "ia doesn't seem to be complete!; $σ"
+
+        if isterminal(τ)
+            lhs, rhs = value(τ)
+            # lhs is a suffix of v·x, so we delete it from v
+            resize!(v, length(v) - length(lhs) + 1)
+            # and prepend rhs to w
+            prepend!(w, rhs)
+            # now we need to rewind the path
+            resize!(path, length(path) - length(lhs) + 1)
+            # @assert trace(v, ia) == (length(v), last(path))
+        else
+            push!(v, x)
+            push!(path, τ)
+        end
+    end
+    return v
+end

--- a/src/kbc_automaton.jl
+++ b/src/kbc_automaton.jl
@@ -14,7 +14,7 @@ function check_local_confluence!(
     rewriting,
     r₁::Rule,
     r₂::Rule,
-    work::kbWork,
+    work::Workspace,
 )
     l = length(stack)
     stack = find_critical_pairs!(stack, rewriting, r₁, r₂, work)
@@ -35,7 +35,7 @@ function rebuild!(
     stack,
     i::Integer = 1,
     j::Integer = 1,
-    work::kbWork = kbWork(rws),
+    work::Workspace = Workspace(rws),
 )
     # this function does a few things at the same time:
     # 1. empty stack by appending new rules to rws maintaining its reducibility;
@@ -81,9 +81,7 @@ function knuthbendix2automaton!(
     rws::RewritingSystem{W},
     settings::Settings = Settings(),
 ) where {W}
-    work = kbWork(rws)
-    rws = reduce!(rws, work)
-
+    rws = reduce!(rws)
     try
         prog = Progress(
             count(isactive, rws.rwrules),
@@ -94,6 +92,7 @@ function knuthbendix2automaton!(
 
         # rws is reduced now so we can create its index
         idxA = IndexAutomaton(rws)
+        work = Workspace(rws, idxA)
         stack = Vector{Tuple{W,W}}()
 
         i = 1

--- a/src/kbs.jl
+++ b/src/kbs.jl
@@ -15,7 +15,7 @@ remove_inactive!(rws) = (filter!(isactive, rws.rwrules); rws)
 
 function reduce!(
     rws::RewritingSystem,
-    work::kbWork = kbWork(rws);
+    work::Workspace = Workspace(rws);
     sort_rules = true,
 )
     remove_inactive!(rws)
@@ -115,7 +115,7 @@ function knuthbendix2!(
     rws::RewritingSystem{W},
     settings::Settings = Settings(),
 ) where {W}
-    work = kbWork(rws)
+    work = Workspace(rws)
     rws = reduce!(rws, work)
 
     try
@@ -185,7 +185,7 @@ function knuthbendix2deleteinactive!(
     rws::RewritingSystem{W},
     settings::Settings = Settings(),
 ) where {W}
-    work = kbWork{eltype(W)}()
+    work = Workspace(rws)
     rws = reduce!(rws, work)
 
     try

--- a/src/rebuilding_idxA.jl
+++ b/src/rebuilding_idxA.jl
@@ -81,21 +81,19 @@ function _is_valid_direct_edge(σ, label)
 end
 
 function rebuild_skew_edges!(idxA::IndexAutomaton)
-    # add missing loops at the root (start of the induction)
-    α = initial(idxA)
-    for x in 1:max_degree(α)
-        if !hasedge(idxA, α, x)
-            addedge!(idxA, α, α, x)
-        end
-    end
-
-    # this has to be done in breadth-first fashion
+    # rebuilding has to be done in breadth-first fashion
     # to ensure that trace(U, idxA) is successful
+
+    # since we're rebuilding idxA the induction step is already done
     for states in idxA.states
         for σ in states # states of particular radius
             # iscomplete(σ) && continue
             isterminal(σ) && continue
 
+            # IDEA: if we have suffix(parent(σ)), then τ could be computed as
+            # τ = suffix(parent(σ))[last(id(σ))]
+            # pros: τ in constant time (independent of length(id(σ)))
+            # cons: enlarge State by 2 words (pointers)
             τ = let U = @view id(σ)[2:end]
                 l, τ = trace(U, idxA) # we're tracing a shorter word, so...
                 @assert l == length(U) # the whole U defines a path in A and

--- a/src/rebuilding_idxA.jl
+++ b/src/rebuilding_idxA.jl
@@ -1,0 +1,115 @@
+function _rebuild!(idxA::IndexAutomaton, rws::RewritingSystem)
+    # Most of the information in idxA can be reused;
+    # however here we just rebuild it from scratch
+    at = IndexAutomaton(rws)
+    idxA.initial = at.initial
+    idxA.states = at.states
+    return idxA
+end
+
+function rebuild!(idxA::IndexAutomaton, rws::RewritingSystem)
+    # mark all states as not up to date
+    for states in idxA.states
+        for σ in states
+            σ.uptodate = false
+            σ.data = 0
+        end
+    end
+
+    # rebuild direct edges
+    for rule in rules(rws)
+        rebuild_direct_path!(idxA, rule)
+    end
+
+    # remove redundant states
+    for states in idxA.states
+        filter!(s -> s.uptodate, states)
+    end
+
+    # recompute skew edges if they lead to redundant states
+    idxA = rebuild_skew_edges!(idxA)
+    return idxA
+end
+
+function rebuild_direct_path!(idxA::IndexAutomaton, rule::Rule)
+    α = initial(idxA)
+    S = typeof(α)
+    n = max_degree(α)
+    lhs, _ = rule
+    σ = α
+    σ.data += 1
+    for (radius, letter) in enumerate(lhs)
+        if !hasedge(idxA, σ, letter)
+            # τ = S(lhs[1:radius], 0, max_degree=n)
+            τ = S(@view(lhs[1:radius]), 0, max_degree = n)
+            addstate!(idxA, τ)
+            addedge!(idxA, σ, τ, letter)
+        else # σ[letter] is already defined
+            # we're rebuilding so there's still some work to do
+            σl = σ[letter]
+            if length(id(σl)) < radius
+                # the edge is skew instead of direct
+                τ = S(@view(lhs[1:radius]), 0, max_degree = n)
+                addstate!(idxA, τ)
+                addedge!(idxA, σ, τ, letter)
+            elseif isterminal(σl) && id(σl) ≠ lhs
+                # the edge leads to a redundant terminal state
+                @warn "terminal state in the middle of the direct path found:" rule σl
+                τ = S(σl.transitions, id(σl))
+                τ.data = 0
+                addstate!(idxA, τ)
+                addedge!(idxA, σ, τ, letter)
+            else # finally it's a good one, so we keep it!
+                σl.uptodate = true
+                if @view(id(σl)[1:end-1]) ≠ id(σ) && id(σl)[end] == letter
+                    @error "While producing direct edges" rule radius σ σ[letter]
+                    throw("This shouldn't happen")
+                end
+            end
+        end
+        @assert id(σ[letter]) == @view lhs[1:radius]
+
+        σ = σ[letter]
+        σ.data += 1
+    end
+    setvalue!(σ, rule)
+    return idxA
+end
+
+function _is_valid_direct_edge(σ, label)
+    return σ[label].uptodate && length(id(σ[label])) == length(id(σ)) + 1
+end
+
+function rebuild_skew_edges!(idxA::IndexAutomaton)
+    # add missing loops at the root (start of the induction)
+    α = initial(idxA)
+    for x in 1:max_degree(α)
+        if !hasedge(idxA, α, x)
+            addedge!(idxA, α, α, x)
+        end
+    end
+
+    # this has to be done in breadth-first fashion
+    # to ensure that trace(U, idxA) is successful
+    for states in idxA.states
+        for σ in states # states of particular radius
+            # iscomplete(σ) && continue
+            isterminal(σ) && continue
+
+            τ = let U = @view id(σ)[2:end]
+                l, τ = trace(U, idxA) # we're tracing a shorter word, so...
+                @assert l == length(U) # the whole U defines a path in A and
+                @assert iscomplete(τ) # (by the induction step)
+                τ
+            end
+
+            for label in 1:max_degree(σ)
+                if hasedge(idxA, σ, label) && _is_valid_direct_edge(σ, label)
+                    continue
+                end
+                addedge!(idxA, σ, τ[label], label)
+            end
+        end
+    end
+    return idxA
+end

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -12,7 +12,7 @@ Rewrites word `u` (from left) using `rewriting` object. The object must implemen
     isempty(rewriting) && return u
     store!(wbuff, u)
     v = rewrite_from_left!(vbuff, wbuff, rewriting)
-    return W(v)
+    return W(v, false)
 end
 
 function rewrite_from_left!(v::AbstractWord, w::AbstractWord, A::Any)

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -1,5 +1,5 @@
 @testset "States" begin
-    s = KnuthBendix.State{String,Int,String}("AAA", max_degree = 3)
+    s = KnuthBendix.State{String,Int,String}("AAA", 0, max_degree = 3)
     @test s isa KnuthBendix.State
     t = typeof(s)("BBB", 15, max_degree = 3)
     fail = typeof(s)()

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -11,7 +11,7 @@
     @test !KnuthBendix.isfail(t)
     @test KnuthBendix.isfail(fail)
 
-    @test_throws String KnuthBendix.value(s)
+    @test_throws UndefRefError KnuthBendix.value(s)
 
     KnuthBendix.setvalue!(s, "10")
     @test KnuthBendix.isterminal(s)


### PR DESCRIPTION
* use views for `idxA` states `id`s
* update `idxA` instead of rebuilding it from scratch

```julia
using Revise
using KnuthBendix
using Profile, PProf

function RWS_Example_237_abaB(n)
    Al = Alphabet([:a, :b, :B])
    KnuthBendix.setinverse!(Al, :b, :B)

    a, b, B = [Word{Int8}([i]) for i in 1:length(Al)]
    ε = one(a)

    eqns = [a^2 => ε, b^3 => ε, (a * b)^7 => ε, (a * b * a * B)^n => ε]

    R = RewritingSystem(eqns, LenLex(Al))
    return R
end

r = let R = RWS_Example_237_abaB(8), nr = 2000, stack_size = 250

    @time r = KnuthBendix.knuthbendix(
        R,
        KnuthBendix.Settings(
            max_rules = nr,
            verbosity = 0,
            stack_size = stack_size,
        ),
        implementation = :index_automaton,
    )
    @info length(r.rwrules) stack_size
end
```
takes
```
20.504774 seconds (106.63 k allocations: 24.168 MiB, 0.09% gc time)
```
