### PR TITLE
Make IndexAutomaton deterministic

### DIFF
--- a/src/Automata/index_automaton.jl
+++ b/src/Automata/index_automaton.jl
@@ -87,19 +87,19 @@ function self_complete!(idxA::IndexAutomaton, σ::State; override = false)
     return idxA
 end
 
-function iscomplete(σ::State, idxA::IndexAutomaton)
-    complete = true
+function has_fail_edges(σ::State, idxA::IndexAutomaton)
+    fail_edges = false
     for label in 1:max_degree(σ)
-        complete &= !isfail(idxA, σ[label])
+        fail_edges |= isfail(idxA, σ[label])
     end
-    return complete
+    return fail_edges
 end
 
 function skew_edges!(idxA::IndexAutomaton)
     # add missing loops at the root (start of the induction)
     α = initial(idxA)
-    if !iscomplete(α, idxA)
-        self_complete!(idxA, σ, override = false)
+    if has_fail_edges(α, idxA)
+        self_complete!(idxA, α, override = false)
     end
 
     # this has to be done in breadth-first fashion
@@ -110,8 +110,8 @@ function skew_edges!(idxA::IndexAutomaton)
                 self_complete!(idxA, σ, override = true)
                 continue
             end
-
-            iscomplete(σ, idxA) && continue
+            # now check if σ has any failed edges
+            has_fail_edges(σ, idxA) || continue
             # so that we don't trace unnecessarily
 
             τ = let U = @view id(σ)[2:end]

--- a/src/Automata/interface.jl
+++ b/src/Automata/interface.jl
@@ -39,8 +39,12 @@ function trace(label, A::Automaton{S}, σ::S) where {S} end
 """
 	trace(w::AbstractVector, A::Automaton[, σ=initial(A)])
 Return a pair `(l, τ)`, where
- * `l` is the length of the longest prefix of `w` which defines a path starting at `σ` in `A` and
+ * `l` is the length of the longest prefix of `w` which defines a path starting
+ at `σ` in `A` and
  * `τ` is the last state (node) on the path.
+
+Note: if `w` defines a path to a _fail state_ the last non-fail state will be
+returned.
 """
 @inline function trace(
     w::AbstractVector,
@@ -49,7 +53,9 @@ Return a pair `(l, τ)`, where
 ) where {S}
     for (i, l) in enumerate(w)
         τ = trace(l, A, σ)
-        isnothing(τ) && return i - 1, σ
+        if isnothing(τ) || isfail(A, τ)
+            return i - 1, σ
+        end
         σ = τ
     end
     return length(w), σ

--- a/src/Automata/interface.jl
+++ b/src/Automata/interface.jl
@@ -52,8 +52,10 @@ returned.
     σ::S = initial(A),
 ) where {S}
     for (i, l) in enumerate(w)
-        τ = trace(l, A, σ)
-        if isnothing(τ) || isfail(A, τ)
+        if hasedge(A, σ, l)
+            τ = trace(l, A, σ)
+        end
+        if isfail(A, τ)
             return i - 1, σ
         end
         σ = τ

--- a/src/Automata/interface.jl
+++ b/src/Automata/interface.jl
@@ -19,6 +19,18 @@ function hasedge(at::Automaton{S}, σ::S, label) where {S} end
 function addedge!(at::Automaton{S}, src::S, dst::S, label) where {S} end
 
 """
+    isfail(A::Automaton, σ)
+Check if state `σ` is a fail state in automaton `A`.
+"""
+function isfail(A::Automaton{S}, σ::S) where {S} end
+
+"""
+    isterminal(A::Automaton, σ)
+Check if state `σ` is a terminal state of automaton `A`.
+"""
+function isterminal(A::Automaton{S}, σ::S) where {S} end
+
+"""
 	trace(label, A::Automaton, σ)
 Return `τ` if `(σ, label, τ)` is in `A`, otherwise return nothing.
 """

--- a/src/Automata/rebuilding_idxA.jl
+++ b/src/Automata/rebuilding_idxA.jl
@@ -33,16 +33,15 @@ function rebuild!(idxA::IndexAutomaton, rws::RewritingSystem)
 end
 
 function rebuild_direct_path!(idxA::IndexAutomaton, rule::Rule)
-    α = initial(idxA)
-    S = typeof(α)
-    n = max_degree(α)
     lhs, _ = rule
-    σ = α
+    n = max_degree(initial(idxA))
+
+    σ = initial(idxA)
     σ.data += 1
     for (radius, letter) in enumerate(lhs)
-        if !hasedge(idxA, σ, letter)
+        if isfail(idxA, σ[letter])
             # τ = S(lhs[1:radius], 0, max_degree=n)
-            τ = S(@view(lhs[1:radius]), 0, max_degree = n)
+            τ = State(idxA.fail, @view(lhs[1:radius]), 0, max_degree = n)
             addstate!(idxA, τ)
             addedge!(idxA, σ, τ, letter)
         else # σ[letter] is already defined
@@ -50,14 +49,13 @@ function rebuild_direct_path!(idxA::IndexAutomaton, rule::Rule)
             σl = σ[letter]
             if length(id(σl)) < radius
                 # the edge is skew instead of direct
-                τ = S(@view(lhs[1:radius]), 0, max_degree = n)
+                τ = State(idxA.fail, @view(lhs[1:radius]), 0, max_degree = n)
                 addstate!(idxA, τ)
                 addedge!(idxA, σ, τ, letter)
-            elseif isterminal(σl) && id(σl) ≠ lhs
+            elseif isterminal(idxA, σl) && id(σl) ≠ lhs
                 # the edge leads to a redundant terminal state
                 @warn "terminal state in the middle of the direct path found:" rule σl
-                τ = S(σl.transitions, id(σl))
-                τ.data = 0
+                τ = typeof(α)(σl.transitions, id(σl), 0)
                 addstate!(idxA, τ)
                 addedge!(idxA, σ, τ, letter)
             else # finally it's a good one, so we keep it!
@@ -84,12 +82,20 @@ end
 function rebuild_skew_edges!(idxA::IndexAutomaton)
     # rebuilding has to be done in breadth-first fashion
     # to ensure that trace(U, idxA) is successful
-
     # since we're rebuilding idxA the induction step is already done
     for states in idxA.states
         for σ in states # states of particular radius
-            # iscomplete(σ) && continue
-            isterminal(σ) && continue
+            if isterminal(idxA, σ)
+                self_complete!(idxA, σ, override=true)
+                continue
+            end
+
+            complete = true
+            for label in 1:max_degree(σ)
+                complete &= !isfail(idxA, σ[label]) && _is_valid_direct_edge(σ, label)
+            end
+            complete && continue
+            # so that we don't trace unnecessarily
 
             # IDEA: if we have suffix(parent(σ)), then τ could be computed as
             # τ = suffix(parent(σ))[last(id(σ))]
@@ -103,10 +109,9 @@ function rebuild_skew_edges!(idxA::IndexAutomaton)
             end
 
             for label in 1:max_degree(σ)
-                if hasedge(idxA, σ, label) && _is_valid_direct_edge(σ, label)
-                    continue
+                if isfail(idxA, σ[label]) || !_is_valid_direct_edge(σ, label)
+                    addedge!(idxA, σ, τ[label], label)
                 end
-                addedge!(idxA, σ, τ[label], label)
             end
         end
     end

--- a/src/Automata/rebuilding_idxA.jl
+++ b/src/Automata/rebuilding_idxA.jl
@@ -83,13 +83,14 @@ function rebuild_skew_edges!(idxA::IndexAutomaton)
     for states in idxA.states
         for σ in states # states of particular radius
             if isterminal(idxA, σ)
-                self_complete!(idxA, σ, override=true)
+                self_complete!(idxA, σ, override = true)
                 continue
             end
 
             σ_is_done = true
             for label in 1:max_degree(σ)
-                σ_is_done &= !isfail(idxA, σ[label]) && _is_valid_direct_edge(σ, label)
+                σ_is_done &=
+                    !isfail(idxA, σ[label]) && _is_valid_direct_edge(σ, label)
             end
             σ_is_done && continue
             # so that we don't trace unnecessarily

--- a/src/Automata/rebuilding_idxA.jl
+++ b/src/Automata/rebuilding_idxA.jl
@@ -34,14 +34,11 @@ end
 
 function rebuild_direct_path!(idxA::IndexAutomaton, rule::Rule)
     lhs, _ = rule
-    n = max_degree(initial(idxA))
-
     σ = initial(idxA)
     σ.data += 1
     for (radius, letter) in enumerate(lhs)
         if isfail(idxA, σ[letter])
-            # τ = S(lhs[1:radius], 0, max_degree=n)
-            τ = State(idxA.fail, @view(lhs[1:radius]), 0, max_degree = n)
+            τ = State(idxA.fail, @view(lhs[1:radius]), 0)
             addstate!(idxA, τ)
             addedge!(idxA, σ, τ, letter)
         else # σ[letter] is already defined
@@ -49,7 +46,7 @@ function rebuild_direct_path!(idxA::IndexAutomaton, rule::Rule)
             σl = σ[letter]
             if length(id(σl)) < radius
                 # the edge is skew instead of direct
-                τ = State(idxA.fail, @view(lhs[1:radius]), 0, max_degree = n)
+                τ = State(idxA.fail, @view(lhs[1:radius]), 0)
                 addstate!(idxA, τ)
                 addedge!(idxA, σ, τ, letter)
             elseif isterminal(idxA, σl) && id(σl) ≠ lhs

--- a/src/Automata/rebuilding_idxA.jl
+++ b/src/Automata/rebuilding_idxA.jl
@@ -3,6 +3,7 @@ function _rebuild!(idxA::IndexAutomaton, rws::RewritingSystem)
     # however here we just rebuild it from scratch
     at = IndexAutomaton(rws)
     idxA.initial = at.initial
+    idxA.fail = at.fail
     idxA.states = at.states
     return idxA
 end

--- a/src/Automata/rebuilding_idxA.jl
+++ b/src/Automata/rebuilding_idxA.jl
@@ -87,11 +87,11 @@ function rebuild_skew_edges!(idxA::IndexAutomaton)
                 continue
             end
 
-            complete = true
+            σ_is_done = true
             for label in 1:max_degree(σ)
-                complete &= !isfail(idxA, σ[label]) && _is_valid_direct_edge(σ, label)
+                σ_is_done &= !isfail(idxA, σ[label]) && _is_valid_direct_edge(σ, label)
             end
-            complete && continue
+            σ_is_done && continue
             # so that we don't trace unnecessarily
 
             # IDEA: if we have suffix(parent(σ)), then τ could be computed as
@@ -101,7 +101,7 @@ function rebuild_skew_edges!(idxA::IndexAutomaton)
             τ = let U = @view id(σ)[2:end]
                 l, τ = trace(U, idxA) # we're tracing a shorter word, so...
                 @assert l == length(U) # the whole U defines a path in A and
-                @assert iscomplete(τ) # (by the induction step)
+                @assert !has_fail_edges(τ, idxA) # (by the induction step)
                 τ
             end
 

--- a/src/Automata/states.jl
+++ b/src/Automata/states.jl
@@ -11,8 +11,8 @@ mutable struct State{I,D,V}
     end
 end
 
-function State(fail::State{I,D,V}, id, data; max_degree::Integer) where {I,D,V}
-    return State{I,D,V}(fill(fail, max_degree), id, data)
+function State(fail::State{I,D,V}, id, data) where {I,D,V}
+    return State{I,D,V}(fill(fail, max_degree(fail)), id, data)
 end
 
 function State{I,D,V}(id, data; max_degree::Integer) where {I,D,V}

--- a/src/Automata/states.jl
+++ b/src/Automata/states.jl
@@ -35,7 +35,6 @@ Base.setindex!(s::State, v::State, i::Integer) = s.transitions[i] = v
 
 max_degree(s::State) = length(s.transitions)
 degree(s::State) = count(i -> hasedge(s, i), 1:max_degree(s))
-iscomplete(s::State) = any(hasedge(s, i) for i in 1:max_degree(s))
 
 transitions(s::State) = (s[i] for i in 1:max_degree(s) if hasedge(s, i))
 

--- a/src/Automata/states.jl
+++ b/src/Automata/states.jl
@@ -6,15 +6,18 @@ mutable struct State{I,D,V}
     value::V
 
     State{I,D,V}() where {I,D,V} = new{I,D,V}()
-    function State{I,D,V}(transitions::AbstractVector, id) where {I,D,V}
-        return new{I,D,V}(transitions, true, id)
+    function State{I,D,V}(transitions::AbstractVector, id, data) where {I,D,V}
+        return new{I,D,V}(transitions, true, id, data)
     end
+end
+
+function State(fail::State{I,D,V}, id, data; max_degree::Integer) where {I,D,V}
+    return State{I,D,V}(fill(fail, max_degree), id, data)
 end
 
 function State{I,D,V}(id, data; max_degree::Integer) where {I,D,V}
     S = State{I,D,V}
-    st = S(Vector{S}(undef, max_degree), id)
-    st.data = data
+    st = S(Vector{S}(undef, max_degree), id, data)
     return st
 end
 
@@ -26,16 +29,13 @@ function hasedge(s::State, i::Integer)
     return isassigned(s.transitions, i)
 end
 
-function Base.getindex(s::State, i::Integer)
-    hasedge(s, i) && return s.transitions[i]
-    return nothing
-end
+Base.getindex(s::State, i::Integer) = s.transitions[i]
 
 Base.setindex!(s::State, v::State, i::Integer) = s.transitions[i] = v
 
 max_degree(s::State) = length(s.transitions)
 degree(s::State) = count(i -> hasedge(s, i), 1:max_degree(s))
-iscomplete(s::State) = degree(s) == max_degree(s)
+iscomplete(s::State) = any(hasedge(s, i) for i in 1:max_degree(s))
 
 transitions(s::State) = (s[i] for i in 1:max_degree(s) if hasedge(s, i))
 

--- a/src/Automata/states.jl
+++ b/src/Automata/states.jl
@@ -18,14 +18,12 @@ function State{I,D,V}(id, data; max_degree::Integer) where {I,D,V}
     return st
 end
 
-isfail(s::State) = !isdefined(s, :transitions)
-isterminal(s::State) = isdefined(s, :value)
 id(s::State) = s.id
 value(s::State) = s.value
 setvalue!(s::State, v) = s.value = v
 
 function hasedge(s::State, i::Integer)
-    return isassigned(s.transitions, i) && !isfail(s.transitions[i])
+    return isassigned(s.transitions, i)
 end
 
 function Base.getindex(s::State, i::Integer)
@@ -42,30 +40,17 @@ iscomplete(s::State) = degree(s) == max_degree(s)
 transitions(s::State) = (s[i] for i in 1:max_degree(s) if hasedge(s, i))
 
 function Base.show(io::IO, s::State)
-    if isfail(s)
-        print(io, "fail")
-    elseif isterminal(s)
-        print(io, "TState: ", value(s))
-    else
-        print(io, "NTState: ", id(s), " (data=", s.data, ")")
-    end
+    print(io, "State: ", id(s), " (data=", s.data, ")")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", s::State)
-    if isfail(s)
-        print(io, "fail state")
-    elseif isterminal(s)
-        println(io, "Terminal state")
-        println(io, "\tvalue: $(value(s))")
-    else
-        println(io, "Non-terminal state: ", id(s))
-        println(io, "\tdata: ", s.data)
-        println(io, "\ttransitions:")
-        for l in 1:max_degree(s)
-            !hasedge(s, l) && continue
-            print(io, "\t\t$l → ")
-            show(io, s[l])
-            println(io)
-        end
+    println(io, "Non-terminal state: ", id(s))
+    println(io, "\tdata: ", s.data)
+    println(io, "\ttransitions:")
+    for l in 1:max_degree(s)
+        !hasedge(s, l) && continue
+        print(io, "\t\t$l → ")
+        show(io, s[l])
+        println(io)
     end
 end

--- a/src/Words/bufferwords.jl
+++ b/src/Words/bufferwords.jl
@@ -50,7 +50,7 @@ _growend!(bw::BufferWord, delta::Integer) = Base._growend!(bw.storage, delta)
 Base.size(bw::BufferWord) = (length(bw.lidx:bw.ridx),)
 
 Base.@propagate_inbounds function Base.getindex(bw::BufferWord, n::Integer)
-    checkbounds(bw, n)
+    @boundscheck checkbounds(bw, n)
     return bw.storage[bw.lidx+n-1]
 end
 

--- a/src/Words/interface.jl
+++ b/src/Words/interface.jl
@@ -61,8 +61,8 @@ function Base.:*(w::AbstractWord, v::AbstractWord)
     out = similar(w)
     copyto!(out, w)
     isone(v) && return out
-    resize!(out, length(w)+length(v))
-    copyto!(out, length(w)+1, v, 1)
+    resize!(out, length(w) + length(v))
+    copyto!(out, length(w) + 1, v, 1)
     # append!(out, v)
     return out
 end

--- a/src/Words/interface.jl
+++ b/src/Words/interface.jl
@@ -150,10 +150,11 @@ Check if `u` is a suffix of `v`.
 @inline function issuffix(u::AbstractWord, v::AbstractWord)
     k = length(u)
     k ≤ length(v) || return false
-    @inbounds for i in eachindex(u)
-        u[i] == v[end-k+i] || return false
+    ans = true
+    for i in eachindex(u)
+        @inbounds ans &= u[i] == v[end-k+i]
     end
-    return true
+    return ans
 end
 
 function Base.show(io::IO, ::MIME"text/plain", w::AbstractWord)

--- a/src/helper_structures.jl
+++ b/src/helper_structures.jl
@@ -72,14 +72,15 @@ struct Workspace{T,H}
 end
 
 function Workspace{T}(S::Type) where {T}
-    return (BP = BufferPair{T}; Workspace(BP(S[]), BP(S[]), BP(S[])))
+    BP = BufferPair{T}
+    return Workspace(BP(S[]), BP(S[]), BP(S[]))
 end
 Workspace(::RewritingSystem{W}) where {W} = Workspace{eltype(W)}(Int)
 function Workspace(::RewritingSystem{W}, ::Automata.Automaton{S}) where {W,S}
     return Workspace{eltype(W)}(S)
 end
 
-struct Settings
+mutable struct Settings
     """Terminate Knuth-Bendix completion if the number of rules exceeds `max_rules`."""
     max_rules::Int
     """Reduce the rws and update the indexing automaton whenever the stack
@@ -94,6 +95,7 @@ struct Settings
     max_lenght_overlap::Int
     """Specifies the level of verbosity"""
     verbosity::Int
+    update_progress
 
     function Settings(;
         max_rules = 10000,
@@ -110,6 +112,7 @@ struct Settings
             max_length_rhs,
             max_length_overlap,
             verbosity,
+            (args...) -> nothing,
         )
     end
 end

--- a/src/knuthbendix2.jl
+++ b/src/knuthbendix2.jl
@@ -143,48 +143,24 @@ function knuthbendix2!(
     settings::Settings = Settings(),
 ) where {W}
     work = Workspace(rws)
-    rws = reduce!(rws, work)
+    stack = Vector{Tuple{W,W}}()
 
-    try
-        prog = Progress(
-            count(isactive, rws.rwrules),
-            desc = "Knuth-Bendix completion ",
-            showspeed = true,
-            enabled = settings.verbosity > 0,
-        )
-        stack = Vector{Tuple{W,W}}()
+    for (i, r₁) in enumerate(rules(rws))
+        are_we_stopping(rws, settings) && break
+        for r₂ in rules(rws)
+            isactive(r₁) || break
+            forceconfluence!(rws, stack, r₁, r₂, work)
 
-        for r₁ in rules(rws)
-            are_we_stopping(rws, settings) && break
-            for r₂ in rules(rws)
-                isactive(r₁) || break
-                forceconfluence!(rws, stack, r₁, r₂, work)
-
-                r₁ === r₂ && break
-                isactive(r₁) || break
-                isactive(r₂) || break
-                forceconfluence!(rws, stack, r₂, r₁, work)
-            end
-            prog.n = count(isactive, rws.rwrules)
-            next!(
-                prog,
-                showvalues = [(
-                    Symbol("processing rules (done/total)"),
-                    "$(prog.counter)/$(prog.n)",
-                )],
-            )
+            r₁ === r₂ && break
+            isactive(r₁) || break
+            isactive(r₂) || break
+            forceconfluence!(rws, stack, r₂, r₁, work)
         end
-
-        finish!(prog)
-        remove_inactive!(rws)
-        return rws
-    catch e
-        if e == InterruptException()
-            @warn "Received user interrupt in Knuth-Bendix completion.
-            Returned rws is reduced, but not confluent"
-            return reduce!(rws)
-        else
-            rethrow(e)
+        if settings.verbosity > 0
+            n = count(isactive, rws.rwrules)
+            settings.update_progress!(i, n)
         end
     end
+    remove_inactive!(rws)
+    return rws
 end

--- a/src/knuthbendix2.jl
+++ b/src/knuthbendix2.jl
@@ -158,7 +158,7 @@ function knuthbendix2!(
         end
         if settings.verbosity > 0
             n = count(isactive, rws.rwrules)
-            settings.update_progress!(i, n)
+            settings.update_progress(i, n)
         end
     end
     remove_inactive!(rws)

--- a/src/knuthbendix_base.jl
+++ b/src/knuthbendix_base.jl
@@ -30,7 +30,7 @@ function reduce!(
 
     if sort_rules
         reverse!(rws.rwrules)
-        sort!(rws.rwrules, by = length ∘ first, alg=Base.Sort.InsertionSort)
+        sort!(rws.rwrules, by = length ∘ first, alg = Base.Sort.InsertionSort)
     end
 
     return rws

--- a/src/knuthbendix_base.jl
+++ b/src/knuthbendix_base.jl
@@ -57,26 +57,70 @@ function knuthbendix(
     end
 end
 
+function _kb_progress(prog::Progress, total, current)
+    prog.n = total
+    update!(
+        prog,
+        current,
+        showvalues = [(
+            Symbol("processing rules (done/total)"),
+            "$(current)/$(total)",
+        )],
+    )
+    return prog
+end
+
+function _kb_progress(prog::Progress, total, current, on_stack)
+    prog.n = total
+    update!(
+        prog,
+        current,
+        showvalues = [(
+            Symbol("processing rules (done/total/on stack)"),
+            "$(current)/$(total)/$(on_stack)",
+        )],
+    )
+    return prog
+end
+
 function knuthbendix!(
     rws::RewritingSystem,
     settings::Settings;
     implementation::Symbol = :index_automaton,
 )
-    kb_implementation! = if implementation == :naive_kbs1
-        knuthbendix1!
-    elseif implementation == :naive_kbs2
+    impl_list = (:naive_kbs1, :naive_kbs2, :rule_deletion, :index_automaton)
+    implementation in impl_list || throw(
+        ArgumentError(
+            "Implementation \"$implementation\" of Knuth-Bendix completion is not defined.\n Possible choices are: $(join(impl_list, ", ", " and ")).",
+        ),
+    )
+
+    if implementation == :naive_kbs1
+        if settings.verbosity > 0
+            @info "knuthbendix1 is a simplistic implementation for educational purposes only."
+        end
+        return knuthbendix1!(rws, settings)
+    end
+
+    prog = Progress(
+        count(isactive, rws.rwrules),
+        desc = "Knuth-Bendix completion ",
+        showspeed = true,
+        enabled = settings.verbosity > 0,
+    )
+
+    settings.update_progress = (args...) -> _kb_progress(prog, args...)
+
+    kb_impl! = if implementation == :naive_kbs2
         knuthbendix2!
     elseif implementation == :rule_deletion
         knuthbendix2deleteinactive!
     elseif implementation == :index_automaton
         knuthbendix2automaton!
-    else
-        impl_list = (:naive_kbs1, :naive_kbs2, :rule_deletion, :index_automaton)
-        implementation in impl_list || throw(
-            ArgumentError(
-                "Implementation \"$implementation\" of Knuth-Bendix completion is not defined.\n Possible choices are: $(join(impl_list, ", ", " and ")).",
-            ),
-        )
     end
-    return kb_implementation!(rws, settings)
+
+    reduce!(rws)
+    rws = kb_impl!(rws, settings)
+    finish!(prog)
+    return rws
 end

--- a/src/knuthbendix_base.jl
+++ b/src/knuthbendix_base.jl
@@ -43,11 +43,18 @@ function knuthbendix(
     settings::Settings = Settings();
     implementation::Symbol = :index_automaton,
 )
-    return knuthbendix!(
-        deepcopy(rws),
-        settings;
-        implementation = implementation,
-    )
+    R = deepcopy(rws)
+    try
+        return knuthbendix!(R, settings; implementation = implementation)
+    catch e
+        if e == InterruptException()
+            @warn "Received user interrupt in Knuth-Bendix completion.
+            Returned rws is reduced, but not confluent"
+            return reduce!(R)
+        else
+            rethrow(e)
+        end
+    end
 end
 
 function knuthbendix!(

--- a/src/knuthbendix_delete.jl
+++ b/src/knuthbendix_delete.jl
@@ -20,58 +20,34 @@ function knuthbendix2deleteinactive!(
     settings::Settings = Settings(),
 ) where {W}
     work = Workspace(rws)
-    rws = reduce!(rws, work)
 
-    try
-        prog = Progress(
-            count(isactive, rws.rwrules),
-            desc = "Knuth-Bendix completion ",
-            showspeed = true,
-            enabled = settings.verbosity > 0,
-        )
+    stack = Vector{Tuple{W,W}}()
+    i = 1
+    while i ≤ length(rws.rwrules)
+        are_we_stopping(rws, settings) && break
+        ri = rws.rwrules[i]
+        j = 1
+        while j ≤ i
+            rj = rws.rwrules[j]
 
-        stack = Vector{Tuple{W,W}}()
-        i = 1
-        while i ≤ length(rws.rwrules)
-            are_we_stopping(rws, settings) && break
-            ri = rws.rwrules[i]
-            j = 1
-            while j ≤ i
-                rj = rws.rwrules[j]
+            isactive(ri) || break
+            isactive(rj) || break
+            forceconfluence!(rws, stack, ri, rj, work)
 
-                isactive(ri) || break
-                isactive(rj) || break
-                forceconfluence!(rws, stack, ri, rj, work)
-
-                ri === rj && break
-                isactive(ri) || break
-                isactive(rj) || break
-                forceconfluence!(rws, stack, rj, ri, work)
-                j += 1
-            end
-            rws, i = remove_inactive!(rws, i)
-
-            prog.n = count(isactive, rws.rwrules)
-            update!(
-                prog,
-                i,
-                showvalues = [(
-                    Symbol("processing rules (done/total)"),
-                    "$(prog.counter)/$(prog.n)",
-                )],
-            )
-            i += 1
+            ri === rj && break
+            isactive(ri) || break
+            isactive(rj) || break
+            forceconfluence!(rws, stack, rj, ri, work)
+            j += 1
         end
-        finish!(prog)
-        remove_inactive!(rws)
-        return rws
-    catch e
-        if e == InterruptException()
-            @warn "Received user interrupt in Knuth-Bendix completion.
-            Returned rws is reduced, but not confluent"
-            return reduce!(rws)
-        else
-            rethrow(e)
+        rws, i = remove_inactive!(rws, i)
+
+        if settings.verbosity > 0
+            n = count(isactive, rws.rwrules)
+            update_progress(i, n)
         end
+        i += 1
     end
+    remove_inactive!(rws)
+    return rws
 end

--- a/src/knuthbendix_delete.jl
+++ b/src/knuthbendix_delete.jl
@@ -44,7 +44,7 @@ function knuthbendix2deleteinactive!(
 
         if settings.verbosity > 0
             n = count(isactive, rws.rwrules)
-            update_progress(i, n)
+            settings.update_progress(i, n)
         end
         i += 1
     end

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -106,7 +106,7 @@ function rewrite!(
         τ = σ[x] # next state
         @assert !isnothing(τ) "idxA doesn't seem to be complete!; $σ"
 
-        if Automata.isterminal(τ)
+        if Automata.isterminal(idxA, τ)
             lhs, rhs = Automata.value(τ)
             # lhs is a suffix of v·x, so we delete it from v
             resize!(v, length(v) - length(lhs) + 1)

--- a/src/rewriting_system.jl
+++ b/src/rewriting_system.jl
@@ -23,12 +23,7 @@ function RewritingSystem(
         rls,
         [
             Rule{W}(
-                simplify!(
-                    deepcopy(a),
-                    deepcopy(b),
-                    order,
-                    balance = true,
-                )...,
+                simplify!(deepcopy(a), deepcopy(b), order, balance = true)...,
                 order,
             ) for (a, b) in rwrules
         ],

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -59,7 +59,7 @@ function rules(::Type{W}, o::Ordering) where {W<:AbstractWord}
 end
 
 """
-    simplifyrule!(lhs::AbstractWord, rhs::AbstractWord, A::Alphabet)
+    simplify!(lhs::AbstractWord, rhs::AbstractWord, A::Alphabet)
 Remove invertible (with respect to `A`) common prefixes and suffixes of `lhs` and `rhs`.
 """
 function simplify!(lhs::AbstractWord, rhs::AbstractWord, A::Alphabet)

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -1,55 +1,50 @@
 import KnuthBendix.Automata
 
 @testset "States" begin
-    s = Automata.State{String,Int,String}("AAA", 0, max_degree = 3)
+    S = Automata.State{Symbol,UInt32,String}
+    @test S() isa Automata.State
+
+    fail = S(Vector{S}(undef, 3), :fail, 0)
+
+    s = Automata.State(fail, :AAA, 10)
     @test s isa Automata.State
-    t = typeof(s)("BBB", 15, max_degree = 3)
-    fail = typeof(s)()
-
-    @test !Automata.isterminal(s)
-    @test !Automata.isterminal(t)
-
-    @test !Automata.isfail(s)
-    @test !Automata.isfail(t)
-    @test Automata.isfail(fail)
-
-    @test_throws UndefRefError Automata.value(s)
-
-    Automata.setvalue!(s, "10")
-    @test Automata.isterminal(s)
-    @test Automata.value(s) == "10"
-
-    @test Automata.id(s) == "AAA"
-    @test Automata.id(t) == "BBB"
+    @test Automata.id(s) == :AAA
 
     @test Automata.max_degree(s) == 3
-    @test Automata.degree(s) == 0
-
-    @test !Automata.hasedge(s, 1)
-    @test !Automata.hasedge(s, 2)
-    @test !Automata.hasedge(s, 3)
-
-    s[2] = t
-    @test Automata.hasedge(s, 2)
-    @test Automata.degree(s) == 1
-
-    s[3] = fail
-    @test !Automata.hasedge(s, 3)
-    @test Automata.degree(s) == 1
-    @test !Automata.iscomplete(s)
-
-    s[1] = t
-    @test Automata.hasedge(s, 1)
-    @test Automata.degree(s) == 2
-    @test !Automata.iscomplete(s)
-
-    s[3] = s
-    @test Automata.hasedge(s, 3)
-    @test Automata.iscomplete(s)
     @test Automata.degree(s) == 3
-    @test s[1] == t
-    @test s[2] == t
-    @test s[3] == s
+
+    @test Automata.hasedge(s, 1)
+    @test Automata.hasedge(s, 2)
+    @test Automata.hasedge(s, 3)
+    @test s[1] == fail
+    @test s[2] === s[3] === fail
+
+    @test_throws UndefRefError Automata.value(s)
+    Automata.setvalue!(s, "10")
+    @test Automata.value(s) == "10"
+
+    t = S(:BBB, 15, max_degree = 3)
+    @test Automata.id(t) == :BBB
+    @test Automata.max_degree(t) == 3
+    @test Automata.degree(t) == 0
+
+    @test all(i -> !Automata.hasedge(t, i), 1:3)
+
+    t[1] = t
+    @test Automata.hasedge(t, 1)
+    @test Automata.degree(t) == 1
+
+    t[2] = s
+    @test Automata.hasedge(t, 2)
+    @test Automata.degree(t) == 2
+
+    t[3] = fail
+    @test Automata.hasedge(t, 3)
+    @test Automata.degree(t) == 3
+
+    @test t[1] == t
+    @test t[2] == s
+    @test t[3] == fail
 
     @test sprint(show, s) isa String
     @test sprint(show, MIME"text/plain"(), s) isa String

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -2,7 +2,11 @@ _length(rws) = length(collect(KnuthBendix.rules(rws)))
 
 @testset "KBS1 examples" begin
     R = RWS_Example_5_1()
-    rws = KnuthBendix.knuthbendix(R, implementation = :naive_kbs1)
+    rws = KnuthBendix.knuthbendix(
+        R,
+        KnuthBendix.Settings(verbosity = 1),
+        implementation = :naive_kbs1,
+    )
     @test _length(rws) == 8
     @test collect(KnuthBendix.rules(R))[1:5] ==
           collect(KnuthBendix.rules(rws))[1:5]
@@ -72,7 +76,7 @@ function test_kbs2_methods(R, methods, len; kwargs...)
     rwses = [
         KnuthBendix.knuthbendix(
             R,
-            KnuthBendix.Settings(;kwargs...);
+            KnuthBendix.Settings(; kwargs...);
             implementation = m,
         ) for m in methods
     ]
@@ -114,7 +118,12 @@ end
         ]),
     )
 
-    test_kbs2_methods(R, (:naive_kbs2, :rule_deletion, :index_automaton), 6)
+    test_kbs2_methods(
+        R,
+        (:naive_kbs2, :rule_deletion, :index_automaton),
+        6,
+        verbosity = 1,
+    )
 
     R = RWS_Example_5_4()
     test_kbs2_methods(R, (:naive_kbs2, :rule_deletion, :index_automaton), 11)


### PR DESCRIPTION
A bunch of improvements has been included here:

* Purely syntactic
  - wrap the whole call to `knuthbendix!` in `try`-`catch`
  - define a "callback" to report progress and so that progress reporting is done in one place
* Functional
  - `States` no longer define `isfail` and `isterminal` -- this is `Automaton`s responsibility
  - `IndexAutomaton` is deterministic (by construction) -- as it should.
* Performance
  - add missing `@inbounds` in `BufferWord`s (10% gain on 237-8 Hurwitz example)
  - make `issuffix` simd-friendly (more improvements in the pipeline) (~20%)
  - replace `isassigned` in `hasedge` by `isfail` which just boils down to comparing a pointer (the remaining ~70%) improvement.

The benchmark from #57 now runs in
```
10.159054 seconds (106.69 k allocations: 24.171 MiB, 0.08% gc time)
```
(2 × faster as previously)