### PR TITLE
backtrack

### DIFF
--- a/src/Automata/Automata.jl
+++ b/src/Automata/Automata.jl
@@ -11,4 +11,6 @@ include("interface.jl")
 include("index_automaton.jl")
 include("rebuilding_idxA.jl")
 
+include("backtrack.jl")
+
 end # of module Automata

--- a/src/Automata/backtrack.jl
+++ b/src/Automata/backtrack.jl
@@ -1,0 +1,86 @@
+mutable struct BacktrackSearch{S,At<:Automaton{S}}
+    automaton::At
+    tape::Vector{S}
+    stack::Vector{Int}
+
+    function BacktrackSearch(at::Automaton{S}) where {S}
+        return new{S,typeof(at)}(
+            at,
+            Vector{S}(),
+            Vector{Int}(),
+        )
+    end
+end
+
+_backtrack_oracle(bs, β) = length(signature(bs.automaton, β))+1 ≤ length(bs.tape)
+
+Base.eltype(::Type{<:BacktrackSearch{S}}) where S = S
+Base.IteratorSize(::Type{<:BacktrackSearch}) = Base.SizeUnknown()
+
+function initialize!(bs::BacktrackSearch, β = initial(bs.automaton))
+    resize!(bs.tape, 1)
+    resize!(bs.stack, 0)
+    bs.tape[begin] = β
+    return bs
+end
+
+function (bs::BacktrackSearch)(w::AbstractWord)
+    l,β = trace(@view(w[2:end]), bs.automaton, initial(bs.automaton))
+    if !isone(w)
+        @assert l+1 == length(w)
+    end
+    return initialize!(bs, β)
+end
+
+function Base.iterate(bs::BacktrackSearch, backtracking = false)
+    if backtracking
+        backtrack = true
+        @goto BACKTRACKING
+    else
+        backtrack = false
+    end
+
+    while !isempty(bs.tape) && !backtrack
+        backtrack = _backtrack_oracle(bs, bs.tape[end])
+        # @info "initial info: β = $(id(bs.tape[end]))"
+        # @info "oracle says: backtrack = $backtrack"
+        if !backtrack && isterminal(bs.automaton, bs.tape[end])
+            # @warn "found a terminal state" bs.tape[end]
+            # backtrack = true
+            return bs.tape[end], true
+            # # process critical pair
+            # if critical
+            #     return ((W(a), W(b)), true)
+            # end
+        end
+        if !backtrack
+            # @info bs.stack
+            push!(bs.stack, 1)
+            β_next = trace(bs.stack[end], bs.automaton, bs.tape[end])
+            push!(bs.tape, β_next)
+            # @info "descending the search tree with $(bs.stack[end])"
+            # @info bs.stack
+        else
+            @label BACKTRACKING
+            # @info "exploring the current level"
+            md = max_degree(initial(bs.automaton))
+
+            while backtrack && length(bs.tape) > 1
+                # @info bs.stack
+                if bs.stack[end] < md
+                    # @info "going to the next child"
+                    bs.stack[end] += 1 # pick next letter
+                    β_prev = bs.tape[end-1]
+                    bs.tape[end] = trace(bs.stack[end], bs.automaton, β_prev)
+                    backtrack = false
+                else
+                    # @info "explored all children, backtracking"
+                    pop!(bs.tape)
+                    pop!(bs.stack)
+                end
+                # @info bs.stack
+            end
+        end
+    end
+    return nothing
+end

--- a/src/Automata/backtrack.jl
+++ b/src/Automata/backtrack.jl
@@ -14,9 +14,18 @@ mutable struct BacktrackSearch{S,At<:Automaton{S}}
     end
 end
 
-function _backtrack_oracle(bs, β)
-    β.data > bs.max_age && return true
-    length(signature(bs.automaton, β))+1 ≤ length(bs.tape) && return true
+function _backtrack_oracle(
+    bs::BacktrackSearch,
+    β;
+    max_age = bs.max_age,
+    max_depth=length(signature(bs.automaton, β))
+)
+    β.data > max_age && return true
+    # depth of search exceeds the length of the signature of the last step
+    # equivalently the length of completed word is greater or equal to length(lhs)
+    # i.e. the completion contains the whole signature so that the overlap of the
+    # initial one and terminal is empty
+    length(bs.tape)-1 ≥ max_depth && return true
     return false
 end
 
@@ -30,11 +39,11 @@ function initialize!(bs::BacktrackSearch, β = initial(bs.automaton))
     return bs
 end
 
-function (bs::BacktrackSearch)(w::AbstractWord, age::Integer=typemax(UInt))
+function (bs::BacktrackSearch)(w::AbstractWord; max_age::Integer=typemax(UInt))
     l,β = trace(w, bs.automaton, initial(bs.automaton))
     @assert l == length(w)
     bs = initialize!(bs, β)
-    bs.max_age = age
+    bs.max_age = max_age
     return bs
 end
 

--- a/src/Automata/index_automaton.jl
+++ b/src/Automata/index_automaton.jl
@@ -40,19 +40,18 @@ function IndexAutomaton(rws::RewritingSystem{W}) where {W}
 end
 
 function direct_edges!(idxA::IndexAutomaton, rwrules)
-    for rule in rwrules
-        add_direct_path!(idxA, rule)
+    for (idx, rule) in enumerate(rwrules)
+        add_direct_path!(idxA, rule, idx)
     end
     return idxA
 end
 
-function add_direct_path!(idxA::IndexAutomaton, rule)
+function add_direct_path!(idxA::IndexAutomaton, rule, age)
     lhs, _ = rule
     σ = initial(idxA)
-    σ.data += 1
     for (radius, letter) in enumerate(lhs)
         if isfail(idxA, trace(letter, idxA, σ))
-            τ = State(idxA.fail, @view(lhs[1:radius]), 0)
+            τ = State(idxA.fail, @view(lhs[1:radius]), age)
             addstate!(idxA, τ)
             addedge!(idxA, σ, τ, letter)
         end
@@ -61,7 +60,6 @@ function add_direct_path!(idxA::IndexAutomaton, rule)
         @assert !isnothing(σ)
         @assert !isfail(idxA, σ)
         @assert signature(idxA, σ) == @view lhs[1:radius]
-        σ.data += 1
     end
     setvalue!(σ, rule)
     return idxA

--- a/src/Automata/index_automaton.jl
+++ b/src/Automata/index_automaton.jl
@@ -15,6 +15,8 @@ addedge!(idxA::IndexAutomaton, src::State, dst::State, label) = src[label] = dst
 isfail(idxA::IndexAutomaton, σ::State) = σ === idxA.fail
 isterminal(idxA::IndexAutomaton, σ::State) = isdefined(σ, :value)
 
+signature(idxA::IndexAutomaton, σ::State) = id(σ)
+
 Base.isempty(idxA::Automaton) = degree(initial(idxA)) == 0
 
 function KnuthBendix.word_type(::IndexAutomaton{<:State{S,D,V}}) where {S,D,V}
@@ -58,6 +60,7 @@ function add_direct_path!(idxA::IndexAutomaton, rule)
 
         σ = σ[letter]
         @assert !isfail(idxA, σ)
+        @assert signature(idxA, σ) == @view lhs[1:radius]
         σ.data += 1
     end
     setvalue!(σ, rule)
@@ -65,7 +68,7 @@ function add_direct_path!(idxA::IndexAutomaton, rule)
 end
 
 function addstate!(idxA::IndexAutomaton, σ::State)
-    radius = length(id(σ))
+    radius = length(signature(idxA, σ))
     ls = length(idxA.states)
     if ls < radius
         T = eltype(idxA.states)
@@ -114,7 +117,7 @@ function skew_edges!(idxA::IndexAutomaton)
             has_fail_edges(σ, idxA) || continue
             # so that we don't trace unnecessarily
 
-            τ = let U = @view id(σ)[2:end]
+            τ = let U = @view signature(idxA, σ)[2:end]
                 l, τ = Automata.trace(U, idxA) # we're tracing a shorter word, so...
                 @assert l == length(U) # the whole U defines a path in A and
                 # by the induction step edges from τ lead to non-fail states

--- a/src/Automata/index_automaton.jl
+++ b/src/Automata/index_automaton.jl
@@ -134,3 +134,17 @@ function skew_edges!(idxA::IndexAutomaton)
     end
     return idxA
 end
+
+function Base.show(io::IO, idxA::IndexAutomaton)
+    terminal_count = [
+        count(st -> Automata.isterminal(idxA, st), states) for
+        states in idxA.states
+    ]
+    nstates = sum(length, idxA.states)
+    nst_str = "$nstates state" * (nstates == 1 ? "" : "s")
+    println(
+        io,
+        "index automaton with $nst_str for a rws with $(sum(terminal_count)) rules",
+    )
+    return print(io, idxA.fail)
+end

--- a/src/Automata/index_automaton.jl
+++ b/src/Automata/index_automaton.jl
@@ -23,7 +23,7 @@ function KnuthBendix.word_type(::IndexAutomaton{<:State{S,D,V}}) where {S,D,V}
     return eltype(V)
 end
 
-trace(label::Integer, idxA::IndexAutomaton, σ::State) = σ[label]
+Base.Base.@propagate_inbounds trace(label::Integer, idxA::IndexAutomaton, σ::State) = σ[label]
 
 function IndexAutomaton(rws::RewritingSystem{W}) where {W}
     id = @view one(W)[1:0]

--- a/src/Automata/index_automaton.jl
+++ b/src/Automata/index_automaton.jl
@@ -51,14 +51,14 @@ function add_direct_path!(idxA::IndexAutomaton, rule)
     σ = initial(idxA)
     σ.data += 1
     for (radius, letter) in enumerate(lhs)
-        if isfail(idxA, σ[letter])
+        if isfail(idxA, trace(letter, idxA, σ))
             τ = State(idxA.fail, @view(lhs[1:radius]), 0)
             addstate!(idxA, τ)
             addedge!(idxA, σ, τ, letter)
         end
-        # @assert id(σ[letter]) == @view lhs[1:radius]
 
-        σ = σ[letter]
+        σ = trace(letter, idxA, σ)
+        @assert !isnothing(σ)
         @assert !isfail(idxA, σ)
         @assert signature(idxA, σ) == @view lhs[1:radius]
         σ.data += 1
@@ -83,7 +83,7 @@ end
 
 function self_complete!(idxA::IndexAutomaton, σ::State; override = false)
     for label in 1:max_degree(σ)
-        if override || isfail(idxA, σ[label])
+        if override || isfail(idxA, trace(label, idxA, σ))
             addedge!(idxA, σ, σ, label)
         end
     end
@@ -93,7 +93,7 @@ end
 function has_fail_edges(σ::State, idxA::IndexAutomaton)
     fail_edges = false
     for label in 1:max_degree(σ)
-        fail_edges |= isfail(idxA, σ[label])
+        fail_edges |= isfail(idxA, trace(label, idxA, σ))
     end
     return fail_edges
 end
@@ -128,7 +128,7 @@ function skew_edges!(idxA::IndexAutomaton)
             end
 
             for label in 1:max_degree(σ)
-                if isfail(idxA, σ[label])
+                if isfail(idxA, trace(label, idxA, σ))
                     addedge!(idxA, σ, τ[label], label)
                 end
             end

--- a/src/Automata/interface.jl
+++ b/src/Automata/interface.jl
@@ -52,8 +52,10 @@ returned.
     σ::S = initial(A),
 ) where {S}
     for (i, l) in enumerate(w)
-        τ = trace(l, A, σ)
-        if isnothing(τ) || isfail(A, τ)
+        if hasedge(A, σ, l)
+            τ = trace(l, A, σ)
+        end
+        if isfail(A, τ)
             return i - 1, σ
         end
         σ = τ

--- a/src/Automata/rebuilding_idxA.jl
+++ b/src/Automata/rebuilding_idxA.jl
@@ -60,8 +60,10 @@ function rebuild_direct_path!(idxA::IndexAutomaton, rule::Rule)
                 end
             end
         end
-        @assert id(σ[letter]) == @view lhs[1:radius]
 
+        σ = trace(letter, idxA, σ)
+        @assert !isnothing(σ)
+        @assert !isfail(idxA, σ)
         @assert signature(idxA, σ) == @view lhs[1:radius]
         σ.data += 1
     end

--- a/src/Automata/states.jl
+++ b/src/Automata/states.jl
@@ -29,7 +29,7 @@ function hasedge(s::State, i::Integer)
     return isassigned(s.transitions, i)
 end
 
-Base.getindex(s::State, i::Integer) = s.transitions[i]
+Base.@propagate_inbounds Base.getindex(s::State, i::Integer) = s.transitions[i]
 
 Base.setindex!(s::State, v::State, i::Integer) = s.transitions[i] = v
 
@@ -43,7 +43,7 @@ function Base.show(io::IO, s::State)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", s::State)
-    println(io, "Non-terminal state: ", id(s))
+    println(io, "State: ", id(s))
     println(io, "\tdata: ", s.data)
     println(io, "\ttransitions:")
     for l in 1:max_degree(s)

--- a/src/KnuthBendix.jl
+++ b/src/KnuthBendix.jl
@@ -4,7 +4,7 @@ using ProgressMeter
 
 export Alphabet, Word, RewritingSystem
 export LenLex, WreathOrder, RecursivePathOrder, WeightedLex
-export alphabet, ordering, knuthbendix
+export alphabet, isconfluent, ordering, knuthbendix
 
 include("Words/Words.jl")
 using .Words

--- a/src/KnuthBendix.jl
+++ b/src/KnuthBendix.jl
@@ -24,6 +24,7 @@ include("knuthbendix1.jl")
 include("knuthbendix2.jl")
 include("knuthbendix_delete.jl")
 include("knuthbendix_idxA.jl")
+include("knuthbendix_backtrack.jl")
 
 include("parsing.jl")
 end

--- a/src/knuthbendix2.jl
+++ b/src/knuthbendix2.jl
@@ -13,12 +13,11 @@ end
 
 """
     find_critical_pairs!(stack, rewriting, r₁::Rule, r₂::Rule, work::Workspace)
-Push to `stack` all critical pairs that
-Empty `stack` of (potentially) critical pairs by deriving and adding new rules
-to `rs` resolving the pairs, i.e. maintains local confluence of `rs`.
+Find critical pairs derived from suffix-prefix overlaps of lhses of `r₁` and `r₂`.
 
-This function may deactivate rules in `rs` if they are deemed redundant (e.g.
-follow from the added new rules). See [Sims, p. 76].
+Such failures (i.e. failures to local confluence) arise as `W = ABC` where
+`AB`, `BC` are the left-hand-sides of rules `r₁` and `r₂`, respectively.
+It is assumed that all `A`, `B` and `C` are nonempty.
 """
 function find_critical_pairs!(
     stack,
@@ -32,7 +31,7 @@ function find_critical_pairs!(
     m = min(length(lhs₁), length(lhs₂)) - 1
     W = word_type(rewriting)
 
-    # TODO: cache suffix automaton for lhs₁ to run this in O(m) (obecnie: O(m²))
+    # TODO: cache suffix automaton for lhs₁ to run this in O(m) (currently: O(m²))
     for b in suffixes(lhs₁, 1:m)
         if isprefix(b, lhs₂)
             lb = length(b)

--- a/src/knuthbendix2.jl
+++ b/src/knuthbendix2.jl
@@ -88,10 +88,10 @@ function deactivate_rules!(
     for rule in rules(rws)
         rule == new_rule && continue
         (lhs, rhs) = rule
-        if occursin(new_rule.lhs, lhs)
+        if occursin(first(new_rule), lhs)
             deactivate!(rule)
-            push!(stack, (first(rule), last(rule)))
-        elseif occursin(new_rule.lhs, rhs)
+            push!(stack, (lhs, rhs))
+        elseif occursin(first(new_rule), rhs)
             new_rhs = rewrite!(work.iscritical_1p, rhs, rws)
             update_rhs!(rule, new_rhs)
         end

--- a/src/knuthbendix2.jl
+++ b/src/knuthbendix2.jl
@@ -134,7 +134,8 @@ Warning: forced termination takes place after the number of rules stored within
 the RewritingSystem reaches `max_rules`.
 """
 function knuthbendix2(rws::RewritingSystem; max_rules = 100)
-    return knuthbendix2!(deepcopy(rws), Settings(; max_rules = max_rules))
+    rws = knuthbendix2!(deepcopy(rws), Settings(; max_rules = max_rules))
+    return reduce!(rws)
 end
 
 function knuthbendix2!(

--- a/src/knuthbendix2.jl
+++ b/src/knuthbendix2.jl
@@ -158,7 +158,7 @@ function knuthbendix2!(
         end
         if settings.verbosity > 0
             n = count(isactive, rws.rwrules)
-            settings.update_progress!(i, n)
+            settings.update_progress(i, n)
         end
     end
     remove_inactive!(rws)

--- a/src/knuthbendix_backtrack.jl
+++ b/src/knuthbendix_backtrack.jl
@@ -63,6 +63,8 @@ function find_critical_pairs!(
     return stack
 end
 
+isconfluent(rws::RewritingSystem) = isempty(check_confluence(rws))
+
 """
     check_confluence(rws::RewritingSystem)
 Check if `rws` is confluent and return a stack of critical pairs discovered.

--- a/src/knuthbendix_backtrack.jl
+++ b/src/knuthbendix_backtrack.jl
@@ -98,3 +98,12 @@ function check_confluence!(
 
     return true, stack
 end
+
+function time_to_check_confluence(
+    rws::RewritingSystem,
+    work::Workspace,
+    settings::Settings,
+)
+    return work.confluence_timer > settings.confluence_delay
+end
+

--- a/src/knuthbendix_backtrack.jl
+++ b/src/knuthbendix_backtrack.jl
@@ -1,0 +1,100 @@
+"""
+    find_critical_pairs!(stack, bts, rule, work[, max_age])
+Find critical pairs by completing lhs of `rule` by backtrack search on index automaton.
+
+If `rule` can be written as `P → Q` this function performs a backtrack
+search on `bts.automaton` to find possible completions of `P[2:end]` to a word
+which ends with `P'` where `P' → Q'` is another rule.
+The search backtracks whenever
+ * the depth exceeds length of `P'` to make sure that `P` and `P'` overlap
+(i.e. a suffix of `P` is a prefix of `P'`)
+ * the path leads to a rule older than `max_age`. If no `max_age` is given it
+is determined as the age of `rule`.
+"""
+function find_critical_pairs!(
+    stack,
+    search::Automata.BacktrackSearch,
+    rule::Rule,
+    work::Workspace
+)
+    lhs₁, _ = rule
+
+    _, β = Automata.trace(lhs₁, search.automaton)
+    max_age = β.data
+    return find_critical_pairs!(stack, search, rule, work, max_age)
+end
+
+function find_critical_pairs!(
+    stack,
+    search::Automata.BacktrackSearch,
+    rule::Rule,
+    work::Workspace,
+    max_age
+)
+    lhs₁, rhs₁ = rule
+
+    W = word_type(search.automaton)
+
+    for β in search(@view(lhs₁[2:end]), max_age)
+        # produce a critical pair:
+        @assert β.data ≤ max_age
+        @assert Automata.isterminal(search.automaton, β)
+        lhs₂, rhs₂ = Automata.value(β)
+        lb = length(lhs₂) - length(search.stack)
+
+        if @views lhs₁[end-lb+1:end] != lhs₂[1:lb]
+            @error lb lhs₁[end-lb+1:end] lhs₂[1:lb]
+            throw("Backtrack returned rules with inconsistent prefix-suffix.")
+        end
+
+        @views rhs₁_c, a_rhs₂ = Words.store!(
+            work.find_critical_p,
+            lhs₁[1:end-lb],
+            rhs₂,
+            rhs₁,
+            lhs₂[lb+1:end],
+        )
+        critical, (a, c) = _iscritical(a_rhs₂, rhs₁_c, search.automaton, work)
+        # memory of a and c is owned by work.find_critical_p
+        # so we need to call constructors
+        critical && push!(stack, (W(a, false), W(c, false)))
+    end
+
+    return stack
+end
+
+"""
+    check_confluence(rws::RewritingSystem)
+Check if `rws` is a confluent rewriting system.
+
+Return a boolean flag and a stack of critical pairs discovered in the process.
+"""
+function check_confluence(rws::RewritingSystem{W}) where W
+    stack = Vector{Tuple{W,W}}()
+    return check_confluence!(stack, rws)
+end
+
+function check_confluence!(
+    stack,
+    rws::RewritingSystem{W},
+    idxA::IndexAutomaton = IndexAutomaton(rws),
+    work::Workspace = Workspace(rws, idxA),
+    i = firstindex(rws.rwrules)
+) where W
+    work.confluence_timer = 0
+    backtrack = Automata.BacktrackSearch(idxA)
+    @assert isempty(stack)
+
+    while i ≤ lastindex(rws.rwrules)
+        ri = rws.rwrules[i]
+        isactive(ri) || continue
+        stack = find_critical_pairs!(stack, backtrack, ri, work, typemax(UInt32))
+        if !isempty(stack)
+            work.confluence_timer = 0
+            return false, stack
+        end
+        i += 1
+    end
+
+    return true, stack
+end

--- a/src/knuthbendix_backtrack.jl
+++ b/src/knuthbendix_backtrack.jl
@@ -15,7 +15,7 @@ function find_critical_pairs!(
     stack,
     search::Automata.BacktrackSearch,
     rule::Rule,
-    work::Workspace
+    work::Workspace,
 )
     lhs₁, _ = rule
 
@@ -29,7 +29,7 @@ function find_critical_pairs!(
     search::Automata.BacktrackSearch,
     rule::Rule,
     work::Workspace,
-    max_age
+    max_age,
 )
     lhs₁, rhs₁ = rule
 
@@ -65,11 +65,12 @@ end
 
 """
     check_confluence(rws::RewritingSystem)
-Check if `rws` is a confluent rewriting system.
+Check if `rws` is confluent and return a stack of critical pairs discovered.
 
-Return a boolean flag and a stack of critical pairs discovered in the process.
+While the stack is by no means an exhaustive list of critical pairs, empty stack
+is returned if and only if `rws` is confluent.
 """
-function check_confluence(rws::RewritingSystem{W}) where W
+function check_confluence(rws::RewritingSystem{W}) where {W}
     stack = Vector{Tuple{W,W}}()
     return check_confluence!(stack, rws)
 end
@@ -79,8 +80,8 @@ function check_confluence!(
     rws::RewritingSystem{W},
     idxA::IndexAutomaton = IndexAutomaton(rws),
     work::Workspace = Workspace(rws, idxA),
-    i = firstindex(rws.rwrules)
-) where W
+    i = firstindex(rws.rwrules),
+) where {W}
     work.confluence_timer = 0
     backtrack = Automata.BacktrackSearch(idxA)
     @assert isempty(stack)
@@ -88,15 +89,16 @@ function check_confluence!(
     while i ≤ lastindex(rws.rwrules)
         ri = rws.rwrules[i]
         isactive(ri) || continue
-        stack = find_critical_pairs!(stack, backtrack, ri, work, typemax(UInt32))
+        stack =
+            find_critical_pairs!(stack, backtrack, ri, work, typemax(UInt32))
         if !isempty(stack)
             work.confluence_timer = 0
-            return false, stack
+            return stack
         end
         i += 1
     end
 
-    return true, stack
+    return stack
 end
 
 function time_to_check_confluence(

--- a/src/knuthbendix_idxA.jl
+++ b/src/knuthbendix_idxA.jl
@@ -75,8 +75,8 @@ function knuthbendix2automaton!(
         if time_to_check_confluence(rws, work, settings)
             if isempty(stack)
                 # @info "no new rules found for $(settings.confluence_delay) itrs, attempting a confluence check" i
-                isconfluent, stack = check_confluence!(stack, rws, idxA, work)
-                isconfluent && return rws
+                stack = check_confluence!(stack, rws, idxA, work)
+                isempty(stack) && return rws
                 l = length(stack)
                 # @info """confluence check failed: found $(l) new rule$(l==1 ? "" : "s") while processing""" rule=ri
             else

--- a/src/knuthbendix_idxA.jl
+++ b/src/knuthbendix_idxA.jl
@@ -52,6 +52,8 @@ function Automata.rebuild!(
     remove_inactive!(rws)
     # 3. re-sync the automaton with rws
     idxA = Automata.rebuild!(idxA, rws)
+    work.confluence_timer = 0
+
     return rws, idxA, i, j
 end
 

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -103,7 +103,7 @@ function rewrite!(
     while !isone(w)
         x = popfirst!(w)
         σ = last(history_tape) # current state
-        τ = σ[x] # next state
+        @inbounds τ = Automata.trace(x, idxA, σ) # next state
         @assert !isnothing(τ) "idxA doesn't seem to be complete!; $σ"
 
         if Automata.isterminal(idxA, τ)

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -95,4 +95,6 @@ end
 
     w = Word([1, 3, 4, 1, 4, 4, 1, 1, 4, 2, 3, 2, 4, 2, 2, 3, 1, 2, 1])
     @test KnuthBendix.rewrite(w, rs) == KnuthBendix.rewrite(w, ia)
+
+    @test sprint(show, ia) isa String
 end

--- a/test/backtrack.jl
+++ b/test/backtrack.jl
@@ -1,0 +1,95 @@
+@testset "backtrack" begin
+    R = let n = 3
+        Al = Alphabet([:a, :b, :B])
+        KnuthBendix.setinverse!(Al, :b, :B)
+
+        a, b, B = [Word{Int8}([i]) for i in 1:length(Al)]
+        ε = one(a)
+
+        eqns = [
+            # b*B => ε,
+            # B*b => ε,
+            a^2 => ε,
+            b^3 => ε,
+            (a * b)^7 => ε,
+            (a * b * a * B)^n => ε,
+        ]
+
+        RewritingSystem(eqns, LenLex(Al))
+    end
+
+    a, b, B = [Word{Int8}([i]) for i in 1:3]
+    idxA = Automata.IndexAutomaton(R)
+    search_completion = Automata.BacktrackSearch(idxA)
+
+    let X = collect(search_completion(a))
+        @test length(X) == 3
+        for st in X
+            @test Automata.isterminal(idxA, st)
+            @test first(Automata.value(st)) == Automata.signature(idxA, st)
+        end
+    end
+
+    let X = collect(search_completion(b * a))
+        @test length(X) == 3
+        for st in X
+            @test Automata.isterminal(idxA, st)
+            @test first(Automata.value(st)) == Automata.signature(idxA, st)
+        end
+    end
+    @test collect(search_completion(b * a)) == collect(search_completion(a))
+
+    let X = collect(search_completion(b * a, max_age = 5))
+        @test length(X) == 2
+        for st in X
+            @test Automata.isterminal(idxA, st)
+            @test first(Automata.value(st)) == Automata.signature(idxA, st)
+        end
+    end
+
+    # let X = collect(search_completion(b * a, 5))
+    #     @test length(X) == 2
+    #     @test Automata.signature.(Ref(idxA), X) ⊆ [a^2, (a * b)^7]
+    # end
+
+    @inferred collect(search_completion(b * a, max_age=typemax(Int)))
+
+    R = let n = 4
+        Al = Alphabet([:a, :b, :B])
+        KnuthBendix.setinverse!(Al, :b, :B)
+
+        a, b, B = [Word{Int8}([i]) for i in 1:length(Al)]
+        ε = one(a)
+
+        eqns = [
+            # b*B => ε,
+            # B*b => ε,
+            a^2 => ε,
+            b^3 => ε,
+            (a * b)^7 => ε,
+            (a * b * a * B)^n => ε,
+        ]
+
+        knuthbendix(
+            RewritingSystem(eqns, LenLex(Al)),
+            implementation = :rule_deletion,
+        )
+    end
+
+    idxA = Automata.IndexAutomaton(R)
+    btsearch = Automata.BacktrackSearch(idxA)
+
+    for rule in KnuthBendix.rules(R)
+        lhs₁, _ = rule
+        tests = map(btsearch(lhs₁[2:end])) do st
+            t1 = Automata.isterminal(idxA, st)
+            lhs₂, _ = Automata.value(st)
+            lb = length(lhs₂) - length(btsearch.stack)
+            t2 = lb ≥ 1
+            t3 =  lb < length(lhs₂)
+            t4 = lhs₁[end-lb+1:end] == lhs₂[1:lb]
+            t1 && t2 && t3 && t4
+        end
+        @test all(tests)
+    end
+end

--- a/test/kbmag_parsing.jl
+++ b/test/kbmag_parsing.jl
@@ -1,39 +1,57 @@
 using MacroTools
 
-@testset "kbmag parsing" begin
-    w = MacroTools.postwalk(KnuthBendix.replace_powering, :((a*c*b^2)^3))
-    @test w == :((a*c*(b*b))*(a*c*(b*b))*(a*c*(b*b)))
-    @test KnuthBendix.mult_args!(Symbol[], w) == [:a, :c, :b, :b, :a, :c, :b, :b, :a, :c, :b, :b]
-
+@testset "kbmag" begin
     kb_data = joinpath(@__DIR__, "..", "kb_data")
 
-    let file_content = String(read(joinpath(kb_data, "a4")))
-        # file_content = join(split(file_content), "")
-        rws = KnuthBendix.parse_kbmag(file_content, method=:string)
+    @testset "parsing" begin
+        w = MacroTools.postwalk(KnuthBendix.replace_powering, :((a * c * b^2)^3))
+        @test w == :((a * c * (b * b)) * (a * c * (b * b)) * (a * c * (b * b)))
+        @test KnuthBendix.mult_args!(Symbol[], w) ==
+            [:a, :c, :b, :b, :a, :c, :b, :b, :a, :c, :b, :b]
 
-        @test rws.generators == [Symbol("g.10"), Symbol("g.20"), Symbol("g.30")]
-        @test rws.inverses == [1, 3, 2]
-        @test rws.equations == [[2,2]=>[3], [3,1,3]=>[1,2,1]]
-    end
-
-    let file_content = String(read(joinpath(kb_data, "3a6")))
-        # file_content = join(split(file_content), "")
-        rws = KnuthBendix.parse_kbmag(file_content, method=:ast)
-        @test rws.generators == [:a, :b, :A, :B]
-        @test rws.inverses == [3, 4, 1, 2]
-        @test rws.equations == [
-            [1,1,1]=>Int[],
-            [2,2,2]=>Int[],
-            [1,2,1,2,1,2,1,2]=>Int[],
-            [1,4,1,4,1,4,1,4,1,4]=>Int[]
-        ]
-    end
-
-    for f in readdir(kb_data)
-        rwsgap = let file_content = String(read(joinpath(kb_data, f)))
+        let file_content = String(read(joinpath(kb_data, "a4")))
             # file_content = join(split(file_content), "")
-            method = (f=="a4" ? :string : :ast)
-            rws = KnuthBendix.parse_kbmag(file_content, method=method)
+            rws = KnuthBendix.parse_kbmag(file_content, method = :string)
+
+            @test rws.generators == [Symbol("g.10"), Symbol("g.20"), Symbol("g.30")]
+            @test rws.inverses == [1, 3, 2]
+            @test rws.equations == [[2, 2] => [3], [3, 1, 3] => [1, 2, 1]]
+        end
+
+        let file_content = String(read(joinpath(kb_data, "3a6")))
+            # file_content = join(split(file_content), "")
+            rws = KnuthBendix.parse_kbmag(file_content, method = :ast)
+            @test rws.generators == [:a, :b, :A, :B]
+            @test rws.inverses == [3, 4, 1, 2]
+            @test rws.equations == [
+                [1, 1, 1] => Int[],
+                [2, 2, 2] => Int[],
+                [1, 2, 1, 2, 1, 2, 1, 2] => Int[],
+                [1, 4, 1, 4, 1, 4, 1, 4, 1, 4] => Int[],
+            ]
+        end
+    end
+
+    failed_exs = [
+        "degen4b", # too hard
+        "degen4c", # too hard
+        "e8", # 3.229832 seconds (106.80 k allocations: 14.409 MiB)
+        "f27", # 46.193392 seconds (217.63 k allocations: 44.759 MiB)
+        "f27_2gen", # 21.226852 seconds (183.67 k allocations: 24.295 MiB)
+        "f27monoid", # ordering := "recursive",
+        "freenilpc3", # ordering := "recursive",
+        "funny3", # 10.782928 seconds (176.58 k allocations: 22.722 MiB, 1.02% gc time)
+        "heinnilp", # ordering := "recursive",
+        "m11", # 27.482646 seconds (256.87 k allocations: 31.985 MiB, 0.04% gc time)
+        "nilp2", # ordering := "recursive",
+        "nonhopf", # ordering := "recursive",
+        "verifynilp", # ordering := "recursive",
+    ]
+
+    @testset "kbmag example: $fn" for fn in readdir(kb_data)
+        rwsgap = let file_content = String(read(joinpath(kb_data, fn)))
+            method = (fn == "a4" ? :string : :ast)
+            rws = KnuthBendix.parse_kbmag(file_content, method = method)
             @test rws isa KnuthBendix.RwsGAP
             @test !isempty(rws.generators)
             @test length(rws.generators) == length(rws.inverses)
@@ -42,5 +60,15 @@ using MacroTools
         end
         @test RewritingSystem(rwsgap) isa RewritingSystem
 
+        sett = KnuthBendix.Settings(
+            max_rules = 2000,
+            verbosity = 1,
+            stack_size = 50,
+        )
+        @info fn
+        fn in failed_exs && continue
+        rws = RewritingSystem(rwsgap)
+        @time R = knuthbendix(rws, sett)
+        @test isconfluent(R)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,8 @@ include("abstract_words.jl")
    include("kbs1.jl")
    include("kbs.jl")
 
-   include("kbmag_parsing.jl")
-
    include("rws_examples.jl")
    include("test_examples.jl")
+
+   include("kbmag_parsing.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ include("abstract_words.jl")
    include("orderings.jl")
    include("rewriting.jl")
    include("automata.jl")
+   include("backtrack.jl")
    include("kbs1.jl")
    include("kbs.jl")
 

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -2,7 +2,11 @@ _length(rws) = length(collect(KnuthBendix.rules(rws)))
 
 @testset "KBS1 examples" begin
     R = RWS_Example_5_1()
-    rws = KnuthBendix.knuthbendix(R, implementation = :naive_kbs1)
+    rws = KnuthBendix.knuthbendix(
+        R,
+        KnuthBendix.Settings(verbosity = 1),
+        implementation = :naive_kbs1,
+    )
     @test _length(rws) == 8
     @test collect(KnuthBendix.rules(R))[1:5] ==
           collect(KnuthBendix.rules(rws))[1:5]
@@ -72,7 +76,7 @@ function test_kbs2_methods(R, methods, len; kwargs...)
     rwses = [
         KnuthBendix.knuthbendix(
             R,
-            KnuthBendix.Settings(;kwargs...);
+            KnuthBendix.Settings(; kwargs...);
             implementation = m,
         ) for m in methods
     ]
@@ -114,7 +118,12 @@ end
         ]),
     )
 
-    test_kbs2_methods(R, (:naive_kbs2, :rule_deletion, :index_automaton), 6)
+    test_kbs2_methods(
+        R,
+        (:naive_kbs2, :rule_deletion, :index_automaton),
+        6,
+        verbosity = 1,
+    )
 
     R = RWS_Example_5_4()
     test_kbs2_methods(R, (:naive_kbs2, :rule_deletion, :index_automaton), 11)

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -7,6 +7,7 @@ _length(rws) = length(collect(KnuthBendix.rules(rws)))
         KnuthBendix.Settings(verbosity = 1),
         implementation = :naive_kbs1,
     )
+    @test isconfluent(rws)
     @test _length(rws) == 8
     @test collect(KnuthBendix.rules(R))[1:5] ==
           collect(KnuthBendix.rules(rws))[1:5]
@@ -17,10 +18,13 @@ _length(rws) = length(collect(KnuthBendix.rules(rws)))
         KnuthBendix.Settings(max_rules = 100),
         implementation = :naive_kbs1,
     )
+    @test !isconfluent(rws)
     @test _length(rws) > 50 # there could be less rules that 100 in the irreducible rws
 
     R = RWS_Example_5_3()
     rws = KnuthBendix.knuthbendix(R, implementation = :naive_kbs1)
+    @test isconfluent(rws)
+
     @test _length(rws) == 6
     a, b = Word.([i] for i in 1:2)
     ε = one(a)
@@ -36,10 +40,12 @@ _length(rws) = length(collect(KnuthBendix.rules(rws)))
 
     R = RWS_Example_5_4()
     rws = KnuthBendix.knuthbendix(R, implementation = :naive_kbs1)
+    @test isconfluent(rws)
     @test _length(rws) == 11
 
     R = RWS_Example_5_5()
     rws = KnuthBendix.knuthbendix(R, implementation = :naive_kbs1)
+    @test isconfluent(rws)
     @test _length(rws) == 18
 
     R = RWS_Example_6_4()
@@ -48,6 +54,7 @@ _length(rws) = length(collect(KnuthBendix.rules(rws)))
         KnuthBendix.Settings(max_rules = 100),
         implementation = :naive_kbs1,
     )
+    @test isconfluent(rws)
     @test _length(rws) == 40
 
     R = RWS_Example_6_5()
@@ -56,10 +63,12 @@ _length(rws) = length(collect(KnuthBendix.rules(rws)))
         KnuthBendix.Settings(max_rules = 100),
         implementation = :naive_kbs1,
     )
+    @test isconfluent(rws)
     @test _length(rws) == 40
 
     R = RWS_Closed_Orientable_Surface(3)
     rws = KnuthBendix.knuthbendix(R, implementation = :naive_kbs1)
+    @test isconfluent(rws)
     @test _length(rws) == 16
 
     R = RWS_Coxeter_group_cube()
@@ -68,6 +77,7 @@ _length(rws) = length(collect(KnuthBendix.rules(rws)))
         KnuthBendix.Settings(max_rules = 300),
         implementation = :naive_kbs1,
     )
+    @test isconfluent(rws)
     @test _length(rws) == 205
     @test sprint(show, rws) isa String
 end
@@ -82,6 +92,7 @@ function test_kbs2_methods(R, methods, len; kwargs...)
     ]
     lengths = _length.(rwses)
     @test all(==(len), lengths)
+    @test all(isconfluent, rwses)
 end
 
 @testset "KBS2 examples" begin
@@ -90,6 +101,7 @@ end
     @test _length(rws) == 8
     @test Set(collect(KnuthBendix.rules(R))[1:5]) ==
           Set(collect(KnuthBendix.rules(rws))[1:5])
+    @test isconfluent(rws)
 
     R = RWS_Example_5_2()
     @test_logs (:warn,) KnuthBendix.knuthbendix(
@@ -169,8 +181,8 @@ end
         RWS_Example_5_3(),
         RWS_Example_5_4(),
         RWS_Example_5_5(),
-        # RWS_Example_6_4(),
-        # RWS_Example_6_5(),
+        RWS_Example_6_4(),
+        RWS_Example_6_5(),
         RWS_Closed_Orientable_Surface(4),
     ]
         rws = KnuthBendix.knuthbendix2(R)


### PR DESCRIPTION
Employ a backtrack search on the IndexAutomaton to perform a really fast confluence check.

The benchmark from https://github.com/kalmarek/KnuthBendix.jl/pull/57 now runs in

```
2.451789 seconds (121.91 k allocations: 20.446 MiB)
```
(4×faster than before)

this is mostly due to early confluence check:
```
┌ Info: no new rules found for 10 itrs, attempting a confluence check
└   i = 270
```
which itself takes (!!!)
```
0.009289 seconds (6.14 k allocations: 1.027 MiB)
```
