### PR TITLE
more on backtracking

### DIFF
--- a/docs/src/knuthbendix1.md
+++ b/docs/src/knuthbendix1.md
@@ -53,6 +53,7 @@ knuthbendix1
 forceconfluence!(rws::RewritingSystem, ::Any, ::Any)
 deriverule!(rws::RewritingSystem, ::AbstractWord, ::AbstractWord)
 reduce!(::KBS1AlgPlain, ::RewritingSystem)
+irreducible_subsystem
 ```
 
 [^1]: If you don't like changing the structure while iterating over it you are

--- a/docs/src/rewriting_system.md
+++ b/docs/src/rewriting_system.md
@@ -14,8 +14,8 @@ rules(::RewritingSystem)
 ordering(::RewritingSystem)
 alphabet(::RewritingSystem)
 isirreducible(::AbstractWord, ::RewritingSystem)
-irreduciblesubsystem(::RewritingSystem)
-check_confluence
+isreduced
 isconfluent
+check_confluence
 reduce!(::RewritingSystem, ::Workspace)
 ```

--- a/src/Automata/index_automaton.jl
+++ b/src/Automata/index_automaton.jl
@@ -34,7 +34,15 @@ Base.Base.@propagate_inbounds function trace(
 end
 
 function IndexAutomaton(rws::RewritingSystem{W}) where {W}
-    @assert KnuthBendix.isreduced(rws) "To construct IndexAutomaton you have to reduce rws first"
+    if !KnuthBendix.isreduced(rws)
+        throw(
+            ArgumentError(
+                """`IndexAutomaton` can be constructed from reduced rewriting systems only.
+                Call `KnuthBendix.reduce!(rws)` and try again.""",
+            ),
+        )
+    end
+
     id = @view one(W)[1:0]
     S = State{typeof(id),UInt32,eltype(rules(rws))}
     ord = KnuthBendix.ordering(rws)
@@ -49,6 +57,8 @@ function IndexAutomaton(rws::RewritingSystem{W}) where {W}
 
     return idxA
 end
+
+KnuthBendix.isreduced(idxA::Automata.IndexAutomaton) = true
 
 function direct_edges!(idxA::IndexAutomaton, rwrules)
     for (idx, rule) in enumerate(rwrules)

--- a/src/Automata/index_automaton.jl
+++ b/src/Automata/index_automaton.jl
@@ -34,6 +34,7 @@ Base.Base.@propagate_inbounds function trace(
 end
 
 function IndexAutomaton(rws::RewritingSystem{W}) where {W}
+    @assert KnuthBendix.isreduced(rws) "To construct IndexAutomaton you have to reduce rws first"
     id = @view one(W)[1:0]
     S = State{typeof(id),UInt32,eltype(rules(rws))}
     ord = KnuthBendix.ordering(rws)

--- a/src/Automata/index_automaton.jl
+++ b/src/Automata/index_automaton.jl
@@ -19,10 +19,12 @@ isterminal(idxA::IndexAutomaton, σ::State) = isdefined(σ, :value)
 
 signature(idxA::IndexAutomaton, σ::State) = id(σ)
 
-Base.isempty(idxA::Automaton) = degree(initial(idxA)) == 0
+Base.isempty(idxA::IndexAutomaton) = degree(initial(idxA)) == 0
 
-function KnuthBendix.word_type(::IndexAutomaton{<:State{S,D,V}}) where {S,D,V}
-    return eltype(V)
+KnuthBendix.word_type(at::Automaton) = word_type(typeof(at))
+
+function KnuthBendix.word_type(::Type{<:IndexAutomaton{S}}) where {S}
+    return eltype(valtype(S))
 end
 
 Base.Base.@propagate_inbounds function trace(

--- a/src/Automata/states.jl
+++ b/src/Automata/states.jl
@@ -25,6 +25,8 @@ id(s::State) = s.id
 value(s::State) = s.value
 setvalue!(s::State, v) = s.value = v
 
+Base.valtype(::Type{<:State{I,D,V}}) where {I,D,V} = V
+
 function hasedge(s::State, i::Integer)
     return isassigned(s.transitions, i)
 end

--- a/src/Words/interface.jl
+++ b/src/Words/interface.jl
@@ -54,6 +54,8 @@ end
 Base.convert(::Type{W}, w::AbstractWord) where {W<:AbstractWord} = W(w, false)
 Base.convert(::Type{W}, w::W) where {W<:AbstractWord} = w
 
+Base.empty!(w::AbstractWord) = resize!(w, 0)
+
 # resize + copyto!
 function store!(w::AbstractWord, v::AbstractWord)
     resize!(w, length(v))

--- a/src/helper_structures.jl
+++ b/src/helper_structures.jl
@@ -66,13 +66,13 @@ mutable struct Workspace{T,H}
     confluence_timer::Int
 end
 
-function Workspace{T}(S::Type) where {T}
+function Workspace{T}(VS::Type{<:AbstractVector}) where {T}
     BP = BufferPair{T}
-    return Workspace(BP(S[]), BP(S[]), BP(S[]), 0)
+    return Workspace(BP(VS()), BP(VS()), BP(VS()), 0)
 end
-Workspace(::RewritingSystem{W}) where {W} = Workspace{eltype(W)}(Int)
-function Workspace(::RewritingSystem{W}, ::Automata.Automaton{S}) where {W,S}
-    return Workspace{eltype(W)}(S)
+Workspace(::RewritingSystem{W}) where {W} = Workspace{eltype(W)}(Vector{Int})
+function Workspace(at::Automata.IndexAutomaton{S}) where {S}
+    return Workspace{eltype(word_type(at))}(Vector{S})
 end
 
 mutable struct Settings

--- a/src/helper_structures.jl
+++ b/src/helper_structures.jl
@@ -13,20 +13,12 @@ BufferPair{T}() where {T} = BufferPair{T}(Int[])
 
 @inline function Words.store!(
     bufpair::BufferPair,
-    a::AbstractWord,
-    rhs₂::AbstractWord,
-    rhs₁::AbstractWord,
-    c::AbstractWord,
+    ws::Tuple,
+    vs::Tuple,
 )
-    a_rhs₂ = let Q = Words.store!(bufpair._vWord, a)
-        append!(Q, rhs₂)
-    end
-
-    rhs₁_c = let Q = Words.store!(bufpair._wWord, rhs₁)
-        append!(Q, c)
-    end
-
-    return rhs₁_c, a_rhs₂
+    Q = append!(empty!(bufpair._vWord), ws...)
+    P = append!(empty!(bufpair._wWord), vs...)
+    return Q, P
 end
 
 """

--- a/src/helper_structures.jl
+++ b/src/helper_structures.jl
@@ -46,18 +46,6 @@ function rewrite!(bp::BufferPair, rewriting; kwargs...)
     return v
 end
 
-function _rewrite!(u::AbstractWord, v::AbstractWord, rewriting; history)
-    return rewrite!(u, v, rewriting)
-end
-function _rewrite!(
-    u::AbstractWord,
-    v::AbstractWord,
-    idxA::IndexAutomaton;
-    history,
-)
-    return rewrite!(u, v, idxA; history = history)
-end
-
 mutable struct Workspace{T,H}
     iscritical_1p::BufferPair{T,H}
     iscritical_2p::BufferPair{T,H}

--- a/src/helper_structures.jl
+++ b/src/helper_structures.jl
@@ -117,3 +117,13 @@ mutable struct Settings
         )
     end
 end
+
+function Base.show(io::IO, ::MIME"text/plain", sett::Settings)
+    println(io, typeof(sett), ":")
+    fns = filter!(≠(:update_progress), collect(fieldnames(typeof(sett))))
+    l = mapreduce(length ∘ string, max, fns)
+    for fn in fns
+        fn == :update_progress && continue
+        println(io, rpad(" • $fn", l + 5), " : ", getfield(sett, fn))
+    end
+end

--- a/src/knuthbendix1.jl
+++ b/src/knuthbendix1.jl
@@ -198,13 +198,13 @@ function subwords(w::AbstractWord, minlength = 1, maxlength = length(w))
 end
 
 """
-    irreducible_subsystem(rws::RewritingSystem)
+    irreducible_subsystem(rws::AbstractRewritingSystem)
 Return an array of left sides of rules from rewriting system of which all the
 proper subwords are irreducible with respect to this rewriting system.
 """
-function irreducible_subsystem(rws::RewritingSystem)
+function irreducible_subsystem(rws::AbstractRewritingSystem)
     lsides = Vector{word_type(rws)}()
-    for rule in rws.rwrules
+    for rule in rules(rws)
         lhs = first(rule)
         length(lhs) >= 2 || break
         for sw in subwords(lhs, 2, length(lhs) - 1)

--- a/src/knuthbendix1.jl
+++ b/src/knuthbendix1.jl
@@ -186,3 +186,39 @@ function reduce!(::KBS1AlgPlain, rws::RewritingSystem)
     end
     return rws
 end
+
+"""
+    subwords(w::AbstractWord[, minlength=1, maxlength=length(w)])
+Return an iterator over all `SubWord`s of `w` of length between `minlength` and `maxlength`.
+"""
+function subwords(w::AbstractWord, minlength = 1, maxlength = length(w))
+    n = length(w)
+    return (
+        @view(w[i:j]) for i in 1:n for
+        j in i:n if minlength <= j - i + 1 <= maxlength
+    )
+end
+
+"""
+    irreducible_subsystem(rws::RewritingSystem)
+Return an array of left sides of rules from rewriting system of which all the
+proper subwords are irreducible with respect to this rewriting system.
+"""
+function irreducible_subsystem(rws::RewritingSystem{W}) where {W}
+    lsides = W[]
+    for rule in rws.rwrules
+        lhs = first(rule)
+        length(lhs) >= 2 || break
+        for sw in subwords(lhs, 2, length(lhs) - 1)
+            if !isirreducible(sw, rws)
+                @debug "subword $sw of $lhs is reducible. skipping!"
+                break
+            end
+        end
+        if all(sw -> isirreducible(sw, rws), subwords(lhs, 2, length(lhs) - 1))
+            @debug "all subwords are irreducible; pushing $lhs"
+            push!(lsides, lhs)
+        end
+    end
+    return unique!(lsides)
+end

--- a/src/knuthbendix1.jl
+++ b/src/knuthbendix1.jl
@@ -181,6 +181,7 @@ function reduce!(::KBS1AlgPlain, rws::RewritingSystem)
         [Rule{W}(lhs, rewrite(lhs, rws_dc), ordering(rws)) for lhs in P]
     rws = empty!(rws)
     append!(rws.rwrules, new_rules)
+    rws.reduced = true
     return rws
 end
 

--- a/src/knuthbendix1.jl
+++ b/src/knuthbendix1.jl
@@ -129,7 +129,7 @@ closely `KBS_1` procedure as described in **Section 2.5**[^Sims1994], p. 68.
              Cambridge University Press, 1994.
 """
 function knuthbendix1(rws::RewritingSystem; max_rules = 100, kwargs...)
-    sett = Settings(; max_rules = max_rules, kwargs...),
+    sett = Settings(; max_rules = max_rules, kwargs...)
     return knuthbendix!(KBS1AlgPlain(), deepcopy(rws), sett)
 end
 

--- a/src/knuthbendix2.jl
+++ b/src/knuthbendix2.jl
@@ -40,15 +40,14 @@ function find_critical_pairs!(
             lb = length(b)
             @views rhs₁_c, a_rhs₂ = Words.store!(
                 work.find_critical_p,
-                lhs₁[1:end-lb],
-                rhs₂,
-                rhs₁,
-                lhs₂[lb+1:end],
+                (lhs₁[1:end-lb], rhs₂),
+                (rhs₁, lhs₂[lb+1:end]),
             )
-            critical, (a, c) = _iscritical(a_rhs₂, rhs₁_c, rewriting, work)
+            critical, (P, Q) = _iscritical(a_rhs₂, rhs₁_c, rewriting, work)
             # memory of a and c is owned by work.find_critical_p
             # so we need to call constructors
-            critical && push!(stack, (W(a, false), W(c, false)))
+            critical && push!(stack, (W(P, false), W(Q, false)))
+            # balance!(stack, P, Q, rewriting)
         end
     end
     return stack
@@ -94,7 +93,7 @@ function deactivate_rules!(
             push!(stack, (lhs, rhs))
         elseif occursin(first(new_rule), rhs)
             new_rhs = rewrite!(work.iscritical_1p, rhs, rws)
-            update_rhs!(rule, new_rhs)
+            update!(rule, new_rhs)
         end
     end
 end

--- a/src/knuthbendix2.jl
+++ b/src/knuthbendix2.jl
@@ -93,7 +93,7 @@ function deactivate_rules!(
             push!(stack, (lhs, rhs))
         elseif occursin(first(new_rule), rhs)
             new_rhs = rewrite!(work.iscritical_1p, rhs, rws)
-            update!(rule, new_rhs)
+            Words.store!(rule, new_rhs)
         end
     end
 end

--- a/src/knuthbendix_backtrack.jl
+++ b/src/knuthbendix_backtrack.jl
@@ -51,9 +51,18 @@ rule for which local confluence failed. The returned stack is empty if and only
 if `rws` is confluent.
 """
 function check_confluence(rws::RewritingSystem{W}) where {W}
-    @assert isreduced(rws)
+    if !isreduced(rws)
+        throw(
+            ArgumentError(
+                """Confluence check is implemented for reduced rewriting systems only.
+                You need to call `reduce!(rws)` on your rewriting system first, then try again.""",
+            ),
+        )
+    end
     stack = Vector{Tuple{W,W}}()
-    return check_confluence!(stack, rws, IndexAutomaton(rws), Workspace(idxA))
+    idxA = IndexAutomaton(rws)
+    stack, _ = check_confluence!(stack, rws, idxA, Workspace(idxA))
+    return stack
 end
 
 function check_confluence!(

--- a/src/knuthbendix_backtrack.jl
+++ b/src/knuthbendix_backtrack.jl
@@ -18,13 +18,10 @@ function find_critical_pairs!(
     lhs₁, rhs₁ = rule
 
     W = word_type(search.automaton)
-
-    for β in search(@view(lhs₁[2:end]))
+    for (lhs₂, rhs₂) in search(@view(lhs₁[2:end]))
         # produce a critical pair:
-        @assert Automata.isterminal(search.automaton, β)
-        lhs₂, rhs₂ = Automata.value(β)
-        lb = length(lhs₂) - length(search.tape) + 1
-
+        lb = length(lhs₂) - length(search.history) + 1
+        @assert lb > 0
         @assert @views lhs₁[end-lb+1:end] == lhs₂[1:lb]
 
         @views rhs₁_c, a_rhs₂ = Words.store!(
@@ -74,7 +71,7 @@ function check_confluence!(
 )
     l = length(stack)
     work.confluence_timer = 0
-    backtrack = Automata.BacktrackSearch(idxA)
+    backtrack = Automata.BacktrackSearch(idxA, Automata.ConfluenceOracle())
     for (i, ri) in enumerate(rules(rws))
         stack = find_critical_pairs!(stack, backtrack, ri, work)
         length(stack) > l && return stack, i

--- a/src/knuthbendix_backtrack.jl
+++ b/src/knuthbendix_backtrack.jl
@@ -42,32 +42,16 @@ function find_critical_pairs!(
 end
 
 """
-    isconfluent(rws::RewritingSystem)
-Check if a rewriting system is confluent.
-
-The check follows first by reducing `rws` using `KBS2AlgPlain()`, and then
-constructing its index automaton and running backtrack search for all rules
-of the system.
-
-!!! note
-    `isconfluent` may modify `rws` if it is not already reduced.
-"""
-function isconfluent(rws::RewritingSystem)
-    rws = reduce!(KBS2AlgPlain(), rws)
-    return isempty(check_confluence(rws))
-end
-
-"""
     check_confluence(rws::RewritingSystem)
 Check if a **reduced** rewriting system is confluent.
 
-Return a stack of critical pairs. While the stack is by no means an exhaustive
-list of critical pairs, empty stack is returned if and only if `rws` is
-confluent.
-
-There is also a modifying version `check_confluence!`.
+The check constructs index automaton for `rws` and runs a backtrack search for
+all rules of the system. Return a stack of critical pairs and an index of the
+rule for which local confluence failed. The returned stack is empty if and only
+if `rws` is confluent.
 """
 function check_confluence(rws::RewritingSystem{W}) where {W}
+    @assert isreduced(rws)
     stack = Vector{Tuple{W,W}}()
     return check_confluence!(stack, rws, IndexAutomaton(rws), Workspace(idxA))
 end

--- a/src/knuthbendix_backtrack.jl
+++ b/src/knuthbendix_backtrack.jl
@@ -29,10 +29,8 @@ function find_critical_pairs!(
 
         @views rhs₁_c, a_rhs₂ = Words.store!(
             work.find_critical_p,
-            lhs₁[1:end-lb],
-            rhs₂,
-            rhs₁,
-            lhs₂[lb+1:end],
+            (lhs₁[1:end-lb], rhs₂),
+            (rhs₁, lhs₂[lb+1:end]),
         )
         critical, (a, c) = _iscritical(a_rhs₂, rhs₁_c, search.automaton, work)
         # memory of a and c is owned by work.find_critical_p

--- a/src/knuthbendix_base.jl
+++ b/src/knuthbendix_base.jl
@@ -1,4 +1,4 @@
-function are_we_stopping(rws::RewritingSystem, settings::Settings)
+function are_we_stopping(rws::AbstractRewritingSystem, settings::Settings)
     if nrules(rws) > settings.max_rules
         if settings.verbosity ≥ 1
             @warn """Maximum number of rules ($(settings.max_rules)) reached.
@@ -16,8 +16,8 @@ end
 abstract type CompletionAlgorithm end
 
 """
-    knuthbendix(rws::RewritingSystem[, settings=Settings()])
-    knuthbendix(method::CompletionAlgorithm, rws::RewritingSystem[, settings:Settings()])
+    knuthbendix(rws::AbstractRewritingSystem[, settings=Settings()])
+    knuthbendix(method::CompletionAlgorithm, rws::AbstractRewritingSystem[, settings:Settings()])
 Perform Knuth-Bendix completion on rewriting system `rws` using algorithm
 defined by `method`.
 
@@ -32,21 +32,24 @@ Unless manually interrupted the returned rewriting system will be reduced.
 
 By default `method = KBS2AlgIndexAut()` is used.
 """
-function knuthbendix(rws::RewritingSystem, settings::Settings = Settings();)
+function knuthbendix(
+    rws::AbstractRewritingSystem,
+    settings::Settings = Settings();
+)
     return knuthbendix(KBS2AlgIndexAut(), rws, settings)
 end
 
 function knuthbendix(
     method::CompletionAlgorithm,
-    rws::RewritingSystem,
+    rws::AbstractRewritingSystem,
     settings = Settings();
 )
     rws_dc = deepcopy(rws)
     isconfluent(rws) && return rws_dc
     try
         prog = Progress(
-            length(rws.rwrules),
-            desc = "Knuth-Bendix completion ",
+            length(__rawrules(rws)),
+            desc = "Knuth-Bendix completion ($method) ",
             showspeed = true,
             enabled = settings.verbosity > 0,
         )

--- a/src/knuthbendix_idxA.jl
+++ b/src/knuthbendix_idxA.jl
@@ -65,7 +65,9 @@ function knuthbendix!(
     rws::RewritingSystem{W},
     settings::Settings = Settings(),
 ) where {W}
-    rws = reduce!(method, rws)
+    if !isreduced(rws)
+        rws = reduce!(method, rws)
+    end
     # rws is reduced now so we can create its index
     idxA = IndexAutomaton(rws)
     work = Workspace(idxA)

--- a/src/knuthbendix_idxA.jl
+++ b/src/knuthbendix_idxA.jl
@@ -13,7 +13,7 @@ function Automata.rebuild!(
     stack,
     i::Integer = 1,
     j::Integer = 1,
-    work::Workspace = Workspace(rws, idxA),
+    work::Workspace = Workspace(idxA),
 )
     # this function does a few things at the same time:
     # 1. empty stack by appending new rules to rws maintaining its reducibility;

--- a/src/knuthbendix_idxA.jl
+++ b/src/knuthbendix_idxA.jl
@@ -68,7 +68,7 @@ function knuthbendix!(
     rws = reduce!(method, rws)
     # rws is reduced now so we can create its index
     idxA = IndexAutomaton(rws)
-    work = Workspace(rws, idxA)
+    work = Workspace(idxA)
     stack = Vector{Tuple{W,W}}()
 
     i = 1

--- a/src/knuthbendix_idxA.jl
+++ b/src/knuthbendix_idxA.jl
@@ -2,7 +2,7 @@
 
 struct KBS2AlgIndexAut <: KBS2AlgAbstract end
 
-function time_to_rebuild(::RewritingSystem, stack, settings::Settings)
+function time_to_rebuild(::AbstractRewritingSystem, stack, settings::Settings)
     ss = settings.stack_size
     return ss <= 0 || length(stack) > ss
 end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -209,7 +209,7 @@ RewritingSystem(rwsgap::KbmagRWS) = RewritingSystem{Word{UInt16}}(rwsgap)
 
 function RewritingSystem{W}(rwsgap::KbmagRWS) where {W}
     A = Alphabet(rwsgap.generatorOrder, rwsgap.inverses)
-    rwrules = [W(l) => W(r) for (l, r) in rwsgap.equations]
+    rwrules = [(W(l), W(r)) for (l, r) in rwsgap.equations]
 
     ordering = if rwsgap.ordering == "shortlex"
         LenLex(A)

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -65,7 +65,7 @@ true
 ```
 """
 @inline function rewrite!(v::AbstractWord, w::AbstractWord, rule::Rule)
-    v = resize!(v, 0)
+    v = empty!(v)
     lhs, rhs = rule
     while !isone(w)
         push!(v, popfirst!(w))
@@ -99,7 +99,7 @@ true
 ```
 """
 @inline function rewrite!(v::AbstractWord, w::AbstractWord, A::Alphabet)
-    v = resize!(v, 0)
+    v = empty!(v)
     while !isone(w)
         if isone(v)
             push!(v, popfirst!(w))
@@ -130,7 +130,7 @@ See procedure `REWRITE_FROM_LEFT` from **Section 2.4**[^Sims1994], p. 66.
     w::AbstractWord,
     rws::RewritingSystem,
 )
-    v = resize!(v, 0)
+    v = empty!(v)
     while !isone(w)
         push!(v, popfirst!(w))
         for (lhs, rhs) in rules(rws)
@@ -165,7 +165,7 @@ function rewrite!(
     resize!(history, 1)
     history[1] = Automata.initial(idxA)
 
-    resize!(v, 0)
+    v = empty!(v)
     while !isone(w)
         σ = last(history) # current state
         x = popfirst!(w)

--- a/src/rewriting.jl
+++ b/src/rewriting.jl
@@ -38,14 +38,12 @@ function rewrite(
     return res
 end
 
-function rewrite!(v::AbstractWord, w::AbstractWord, A::Any)
-    msg_ = [
-        "No method for rewriting with $(typeof(A)).",
-        "You need to implement",
-        "KnuthBendix.rewrite!(::AbstractWord, ::AbstractWord, ::$(typeof(A)))",
-        "yourself",
-    ]
-    throw(join(msg_, " "))
+function rewrite!(v::AbstractWord, w::AbstractWord, A::Any; kwargs...)
+    throw(
+        """No method for rewriting with $(typeof(A)). You need to implement
+        `KnuthBendix.rewrite!(::AbstractWord, ::AbstractWord, ::$(typeof(A)); kwargs...)`
+        yourself.""",
+    )
 end
 """
     rewrite!(v::AbstractWord, w::AbstractWord, rule::Rule)
@@ -64,7 +62,12 @@ julia> v == a*A*b^3
 true
 ```
 """
-@inline function rewrite!(v::AbstractWord, w::AbstractWord, rule::Rule)
+@inline function rewrite!(
+    v::AbstractWord,
+    w::AbstractWord,
+    rule::Rule;
+    kwargs...,
+)
     v = empty!(v)
     lhs, rhs = rule
     while !isone(w)
@@ -98,7 +101,12 @@ julia> v == b
 true
 ```
 """
-@inline function rewrite!(v::AbstractWord, w::AbstractWord, A::Alphabet)
+@inline function rewrite!(
+    v::AbstractWord,
+    w::AbstractWord,
+    A::Alphabet;
+    kwargs...,
+)
     v = empty!(v)
     while !isone(w)
         if isone(v)
@@ -125,10 +133,11 @@ See procedure `REWRITE_FROM_LEFT` from **Section 2.4**[^Sims1994], p. 66.
 [^Sims1994]: C.C. Sims _Computation with finitely presented groups_,
              Cambridge University Press, 1994.
 """
-@inline function rewrite!(
+function rewrite!(
     v::AbstractWord,
     w::AbstractWord,
-    rws::RewritingSystem,
+    rws::RewritingSystem;
+    kwargs...,
 )
     v = empty!(v)
     while !isone(w)
@@ -147,8 +156,7 @@ See procedure `REWRITE_FROM_LEFT` from **Section 2.4**[^Sims1994], p. 66.
 end
 
 """
-    rewrite!(v::AbstractWord, w::AbstractWord, idxA::Automata.IndexAutomaton;
-        [history])
+    rewrite!(v::AbstractWord, w::AbstractWord, idxA::Automata.IndexAutomaton)
 Rewrite word `w` storing the result in `v` using index automaton `idx`.
 
 See procedure `INDEX_REWRITE` from **Section 3.5**[^Sims1994], p. 113.
@@ -161,6 +169,7 @@ function rewrite!(
     w::AbstractWord,
     idxA::Automata.IndexAutomaton{S};
     history = S[],
+    kwargs...,
 ) where {S}
     resize!(history, 1)
     history[1] = Automata.initial(idxA)

--- a/src/rewriting_system.jl
+++ b/src/rewriting_system.jl
@@ -96,7 +96,7 @@ Base.empty!(s::RewritingSystem) = (empty!(s.rwrules); s)
 function Base.empty(s::RewritingSystem{W}, o::Ordering = ordering(s)) where {W}
     return RewritingSystem(Rule{W}[], o)
 end
-Base.isempty(s::RewritingSystem) = isempty(rules(s))
+Base.isempty(s::RewritingSystem) = nrules(s) == 0
 
 remove_inactive!(rws::RewritingSystem) = (filter!(isactive, rws.rwrules); rws)
 
@@ -108,6 +108,7 @@ function isirreducible(w::AbstractWord, rws::RewritingSystem)
     return !any(r -> occursin(first(r), w), rules(rws))
 end
 
+## IO, i.e. Tables.jl interface
 
 function _print_rule(io::IO, i, rule, A)
     (lhs, rhs) = rule

--- a/src/rewriting_system.jl
+++ b/src/rewriting_system.jl
@@ -75,42 +75,6 @@ function isirreducible(w::AbstractWord, rws::RewritingSystem)
     return !any(r -> occursin(first(r), w), rules(rws))
 end
 
-"""
-    subwords(w::AbstractWord[, minlength=1, maxlength=length(w)])
-Return an iterator over all `SubWord`s of `w` of length between `minlength` and `maxlength`.
-"""
-function subwords(w::AbstractWord, minlength = 1, maxlength = length(w))
-    n = length(w)
-    return (
-        @view(w[i:j]) for i in 1:n for
-        j in i:n if minlength <= j - i + 1 <= maxlength
-    )
-end
-
-"""
-    irreduciblesubsystem(rws::RewritingSystem)
-Return an array of left sides of rules from rewriting system of which all the
-proper subwords are irreducible with respect to this rewriting system.
-"""
-function irreduciblesubsystem(rws::RewritingSystem{W}) where {W}
-    lsides = W[]
-    for rule in rws.rwrules
-        lhs = first(rule)
-        length(lhs) >= 2 || break
-        for sw in subwords(lhs, 2, length(lhs) - 1)
-            if !isirreducible(sw, rws)
-                @debug "subword $sw of $lhs is reducible. skipping!"
-                break
-            end
-        end
-        if all(sw -> isirreducible(sw, rws), subwords(lhs, 2, length(lhs) - 1))
-            @debug "all subwords are irreducible; pushing $lhs"
-            push!(lsides, lhs)
-        end
-    end
-    return unique!(lsides)
-end
-
 
 function _print_rule(io::IO, i, rule, A)
     (lhs, rhs) = rule

--- a/src/rewriting_system.jl
+++ b/src/rewriting_system.jl
@@ -84,8 +84,7 @@ Check whether the rewriting system is confluent.
 """
 function isconfluent(rws::RewritingSystem)
     if !rws.confluent && isreduced(rws)
-        stack, _ = check_confluence(rws)
-        if isempty(stack)
+        if isempty(check_confluence(rws))
             rws.confluent = true
         end
     end

--- a/src/rewriting_system.jl
+++ b/src/rewriting_system.jl
@@ -1,9 +1,104 @@
+abstract type AbstractRewritingSystem{W<:AbstractWord} end
+
+"""
+    alphabet(rws::AbstractRewritingSystem)
+Return the underlying `Alphabet` of the rewriting system.
+"""
+alphabet(rws::AbstractRewritingSystem) = alphabet(ordering(rws))
+word_type(::AbstractRewritingSystem{W}) where {W} = W
+
+"""
+    isirreducible(w::AbstractWord, rws::RewritingSystem)
+Returns whether a word is irreducible with respect to a given rewriting system
+"""
+function isirreducible(w::AbstractWord, rws::AbstractRewritingSystem)
+    return !any(r -> occursin(first(r), w), rules(rws))
+end
+
+"""
+    rules(rws::AbstractRewritingSystem)
+Return the iterator over **active** rewriting rules.
+"""
+function rules(rws::AbstractRewritingSystem)
+    return Iterators.filter(isactive, __rawrules(rws))
+end
+nrules(rws::AbstractRewritingSystem) = count(isactive, __rawrules(rws))
+
+Base.isempty(rws::AbstractRewritingSystem) = !any(isactive, __rawrules(rws))
+
+## IO, i.e. Tables.jl interface
+
+function _print_rule(io::IO, i, rule, A)
+    (lhs, rhs) = rule
+    print(io, i, ". ")
+    print_repr(io, lhs, A)
+    print(io, "\t → \t")
+    print_repr(io, rhs, A)
+    return
+end
+
+using Tables
+import PrettyTables
+
+Tables.istable(::Type{<:AbstractRewritingSystem}) = true
+
+Tables.rowaccess(::Type{<:AbstractRewritingSystem}) = true
+Tables.rows(rws::AbstractRewritingSystem) = __rawrules(rws)
+
+# Tables.getcolumn(r::Rule, i::Integer) = (t = (lhs, rhs) = r; t[i])
+Tables.columnnames(::Rule) = (:lhs, :rhs)
+Base.getindex(r::Rule, s::Symbol) = getfield(r, s)
+
+function Base.show(io::IO, ::MIME"text/plain", rws::AbstractRewritingSystem)
+    hl_odd = PrettyTables.Highlighter(
+        f = (rule, i, j) -> i % 2 == 0,
+        crayon = PrettyTables.Crayon(;
+            foreground = :dark_gray,
+            negative = true,
+        ),
+    )
+    if isreduced(rws)
+        print(io, "reduced")
+        print(io, isconfluent(rws) ? ", " : " ")
+    end
+    if isconfluent(rws)
+        print(io, "confluent ")
+    end
+    println(
+        io,
+        "rewriting system with ",
+        nrules(rws),
+        " active rules.\n",
+        "rewriting ordering: ",
+        ordering(rws),
+    )
+
+    return PrettyTables.pretty_table(
+        io,
+        rws,
+        show_row_number = true,
+        row_number_column_title = "Rule",
+        formatters = (w, args...) -> sprint(print_repr, w, alphabet(rws)),
+        autowrap = true,
+        linebreaks = true,
+        reserved_display_lines = 3[],
+        columns_width = displaysize(io)[2] ÷ 2 - 8,
+        # vcrop_mode = :middle,
+        # equal_columns_width = true,
+        # crop = :vertical,
+        ellipsis_line_skip = 1,
+        alignment = [:r, :l],
+        highlighters = hl_odd,
+    )
+end
+
 """
     RewritingSystem{W<:AbstractWord, O<:Ordering}
     RewritingSystem(rwrules::Vector{Pair{W,W}}, order[; confluent=false, reduced=false])
 `RewritingSystem` holds the list of ordered (by `order`) rewriting rules of `W<:AbstractWord`s.
 """
-mutable struct RewritingSystem{W<:AbstractWord,O<:Ordering}
+mutable struct RewritingSystem{W<:AbstractWord,O<:Ordering} <:
+               AbstractRewritingSystem{W}
     rules_orig::Vector{Rule{W}}
     rules_alphabet::Vector{Rule{W}}
     rwrules::Vector{Rule{W}}
@@ -61,25 +156,13 @@ function RewritingSystem(
     )
 end
 
-"""
-    rules(rws::RewritingSystem)
-Return the iterator over **active** rewriting rules.
-"""
-rules(rws::RewritingSystem) = Iterators.filter(isactive, rws.rwrules)
-nrules(rws::RewritingSystem) = count(isactive, rws.rwrules)
+__rawrules(rws::RewritingSystem) = rws.rwrules
+
 """
     ordering(rws::RewritingSystem)
 Return the ordering of the rewriting system.
 """
 ordering(rws::RewritingSystem) = rws.order
-"""
-    alphabet(rws::RewritingSystem)
-Return the underlying `Alphabet` of the rewriting system.
-"""
-alphabet(rws::RewritingSystem) = alphabet(ordering(rws))
-word_type(::RewritingSystem{W}) where {W} = W
-
-Base.push!(rws::RewritingSystem, r::Rule) = (push!(rws.rwrules, r); rws)
 
 """
     isreduced(rws::RewritingSystem)
@@ -110,73 +193,11 @@ function isconfluent(rws::RewritingSystem)
     return rws.confluent
 end
 
+Base.push!(rws::RewritingSystem, r::Rule) = (push!(rws.rwrules, r); rws)
 Base.empty!(s::RewritingSystem) = (empty!(s.rwrules); s)
 function Base.empty(s::RewritingSystem{W}, o::Ordering = ordering(s)) where {W}
     return RewritingSystem(Rule{W}[], o)
 end
-Base.isempty(s::RewritingSystem) = nrules(s) == 0
 
 remove_inactive!(rws::RewritingSystem) = (filter!(isactive, rws.rwrules); rws)
 
-"""
-    isirreducible(w::AbstractWord, rws::RewritingSystem)
-Returns whether a word is irreducible with respect to a given rewriting system
-"""
-function isirreducible(w::AbstractWord, rws::RewritingSystem)
-    return !any(r -> occursin(first(r), w), rules(rws))
-end
-
-## IO, i.e. Tables.jl interface
-
-function _print_rule(io::IO, i, rule, A)
-    (lhs, rhs) = rule
-    print(io, i, ". ")
-    print_repr(io, lhs, A)
-    print(io, "\t → \t")
-    print_repr(io, rhs, A)
-    return
-end
-
-using Tables
-import PrettyTables
-
-Tables.istable(::Type{<:RewritingSystem}) = true
-
-Tables.rowaccess(::Type{<:RewritingSystem}) = true
-Tables.rows(rws::RewritingSystem) = rws.rwrules
-
-# Tables.getcolumn(r::Rule, i::Integer) = (t = (lhs, rhs) = r; t[i])
-Tables.columnnames(::Rule) = (:lhs, :rhs)
-Base.getindex(r::Rule, s::Symbol) = getfield(r, s)
-
-function Base.show(io::IO, ::MIME"text/plain", rws::RewritingSystem)
-    hl_odd = PrettyTables.Highlighter(
-        f = (rule, i, j) -> i % 2 == 0,
-        crayon = PrettyTables.Crayon(;
-            foreground = :dark_gray,
-            negative = true,
-        ),
-    )
-    println(
-        io,
-        "Rewriting System with $(nrules(rws)) active rules ordered by $(ordering(rws)):",
-    )
-
-    return PrettyTables.pretty_table(
-        io,
-        rws,
-        show_row_number = true,
-        row_number_column_title = "Rule",
-        formatters = (w, args...) -> sprint(print_repr, w, alphabet(rws)),
-        autowrap = true,
-        linebreaks = true,
-        reserved_display_lines = 3[],
-        columns_width = displaysize(io)[2] ÷ 2 - 8,
-        # vcrop_mode = :middle,
-        # equal_columns_width = true,
-        # crop = :vertical,
-        ellipsis_line_skip = 1,
-        alignment = [:r, :l],
-        highlighters = hl_odd,
-    )
-end

--- a/src/rewriting_system.jl
+++ b/src/rewriting_system.jl
@@ -1,13 +1,31 @@
 """
     RewritingSystem{W<:AbstractWord, O<:Ordering}
-    RewritingSystem(rwrules::Vector{Pair{W,W}}, order, bare=false)
+    RewritingSystem(rwrules::Vector{Pair{W,W}}, order[; confluent=false, reduced=false])
 `RewritingSystem` holds the list of ordered (by `order`) rewriting rules of `W<:AbstractWord`s.
 """
 mutable struct RewritingSystem{W<:AbstractWord,O<:Ordering}
+    rules_orig::Vector{Rule{W}}
+    rules_alphabet::Vector{Rule{W}}
     rwrules::Vector{Rule{W}}
     order::O
     confluent::Bool
     reduced::Bool
+end
+
+function RewritingSystem(
+    rwrules::AbstractVector{<:Rule{W}},
+    order::RewritingOrdering;
+    confluent::Bool = false,
+    reduced::Bool = false,
+) where {W}
+    return RewritingSystem(
+        rwrules,
+        rules(W, order),
+        deepcopy(rwrules),
+        order,
+        confluent,
+        reduced,
+    )
 end
 
 function RewritingSystem(

--- a/src/rewriting_system.jl
+++ b/src/rewriting_system.jl
@@ -124,11 +124,11 @@ function RewritingSystem(
 end
 
 function RewritingSystem(
-    rwrules::Vector{Pair{W,W}},
-    order::O;
+    rwrules::Vector{Tuple{W,W}},
+    order::RewritingOrdering;
     confluent::Bool = false,
     reduced::Bool = false,
-) where {W<:AbstractWord,O<:RewritingOrdering}
+) where {W<:AbstractWord}
     if length(alphabet(order)) > Words._max_alphabet_length(W)
         throw("Type $W can not store words over $(alphabet(order)).")
     end
@@ -200,4 +200,3 @@ function Base.empty(s::RewritingSystem{W}, o::Ordering = ordering(s)) where {W}
 end
 
 remove_inactive!(rws::RewritingSystem) = (filter!(isactive, rws.rwrules); rws)
-

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -8,7 +8,6 @@ end
 deactivate!(r::Rule) = r.active = false
 isactive(r::Rule) = r.active
 
-
 function Words.store!(r::Rule, (lhs, rhs)::Pair)
     Words.store!(r.lhs, lhs)
     Words.store!(r, rhs)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -21,8 +21,7 @@ function Words.store!(r::Rule, new_rhs)
 end
 
 function Rule{W}(l::AbstractWord, r::AbstractWord, o::Ordering) where {W}
-    lhs, rhs = lt(o, l, r) ? (r, l) : (l, r)
-    @assert !lt(o, lhs, rhs) "$lhs should be larger than $rhs"
+    lhs, rhs = ifelse(lt(o, l, r), (r, l), (l, r))
     return Rule{W}(lhs, rhs, hash(lhs, hash(rhs)), true)
 end
 Rule(l::W, r::W, o::Ordering) where {W} = Rule{W}(l, r, o)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -8,7 +8,14 @@ end
 deactivate!(r::Rule) = r.active = false
 isactive(r::Rule) = r.active
 
-function update_rhs!(r::Rule, new_rhs)
+
+function Words.store!(r::Rule, (lhs, rhs)::Pair)
+    Words.store!(r.lhs, lhs)
+    Words.store!(r, rhs)
+    return r
+end
+
+function Words.store!(r::Rule, new_rhs)
     Words.store!(r.rhs, new_rhs)
     r.id = hash(r.lhs, hash(r.rhs))
     return r

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -69,7 +69,7 @@ end
         Word([1, 1, 1, 2, 2, 2, 3, 4, 2, 2, 3, 3, 3, 4, 4, 4, 4, 3, 4, 3, 4, 1])
 
     rs =
-        KnuthBendix.RewritingSystem([A => ε, B => ε], lenlexord, reduced = true)
+        KnuthBendix.RewritingSystem([(A, ε), (B, ε)], lenlexord, reduced = true)
     ia = KnuthBendix.IndexAutomaton(rs)
     @test KnuthBendix.rewrite(testword, rs) ==
           KnuthBendix.rewrite(testword, ia) ==
@@ -77,14 +77,14 @@ end
 
     rs = KnuthBendix.RewritingSystem(
         [
-            a * A => ε,
-            A * a => ε,
-            b * B => ε,
-            B * b => ε,
-            b * a => a * b,
-            b * A => A * b,
-            B * a => a * B,
-            B * A => A * B,
+            (a * A, ε),
+            (A * a, ε),
+            (b * B, ε),
+            (B * b, ε),
+            (b * a, a * b),
+            (b * A, A * b),
+            (B * a, a * B),
+            (B * A, A * B),
         ],
         lenlexord,
         reduced = true,

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -68,7 +68,8 @@ end
     testword =
         Word([1, 1, 1, 2, 2, 2, 3, 4, 2, 2, 3, 3, 3, 4, 4, 4, 4, 3, 4, 3, 4, 1])
 
-    rs = KnuthBendix.RewritingSystem([A => ε, B => ε], lenlexord)
+    rs =
+        KnuthBendix.RewritingSystem([A => ε, B => ε], lenlexord, reduced = true)
     ia = KnuthBendix.IndexAutomaton(rs)
     @test KnuthBendix.rewrite(testword, rs) ==
           KnuthBendix.rewrite(testword, ia) ==
@@ -86,6 +87,7 @@ end
             B * A => A * B,
         ],
         lenlexord,
+        reduced = true,
     )
     ia = KnuthBendix.IndexAutomaton(rs)
 

--- a/test/backtrack.jl
+++ b/test/backtrack.jl
@@ -9,10 +9,10 @@
         eqns = [
             # b*B => ε,
             # B*b => ε,
-            a^2 => ε,
-            b^3 => ε,
-            (a * b)^7 => ε,
-            (a * b * a * B)^n => ε,
+            (a^2, ε),
+            (b^3, ε),
+            ((a * b)^7, ε),
+            ((a * b * a * B)^n, ε),
         ]
 
         RewritingSystem(eqns, LenLex(Al), reduced = true)
@@ -20,24 +20,23 @@
 
     a, b, B = [Word{UInt8}([i]) for i in 1:3]
     idxA = Automata.IndexAutomaton(R)
-    search_completion = Automata.BacktrackSearch(idxA)
+    search_completion =
+        Automata.BacktrackSearch(idxA, Automata.ConfluenceOracle())
 
     let X = collect(search_completion(a))
         @test length(X) == 3
-        for st in X
-            @test Automata.isterminal(idxA, st)
-            @test first(Automata.value(st)) == Automata.signature(idxA, st)
-        end
+        @test first.(X) ==
+              [a * a, (a * b)^6 * a, (a * b * a * B)^2 * (a * b * a)]
     end
 
     let X = collect(search_completion(b * a))
         @test length(X) == 3
-        for st in X
-            @test Automata.isterminal(idxA, st)
-            @test first(Automata.value(st)) == Automata.signature(idxA, st)
-        end
+        @test first.(X) ==
+              [a * a, (a * b)^6 * a, (a * b * a * B)^2 * (a * b * a)]
     end
-    @test collect(search_completion(b * a)) == collect(search_completion(a))
+    @test map(first, search_completion(b)) == [b * b, b * B]
+    @test map(first, search_completion(b * a)) ==
+          map(first, search_completion(b * a))
 
     # let X = collect(search_completion(b * a, max_age = 5))
     #     @test length(X) == 2
@@ -64,24 +63,24 @@
         eqns = [
             # b*B => ε,
             # B*b => ε,
-            a^2 => ε,
-            b^3 => ε,
-            (a * b)^7 => ε,
-            (a * b * a * B)^n => ε,
+            (a^2, ε),
+            (b^3, ε),
+            ((a * b)^7, ε),
+            ((a * b * a * B)^n, ε),
         ]
 
         knuthbendix(RewritingSystem(eqns, LenLex(Al), reduced = true))
     end
 
     idxA = Automata.IndexAutomaton(R)
-    btsearch = Automata.BacktrackSearch(idxA)
+    btsearch = Automata.BacktrackSearch(idxA, Automata.ConfluenceOracle())
 
     for rule in KnuthBendix.rules(R)
         lhs₁, _ = rule
-        tests = map(btsearch(lhs₁[2:end])) do st
-            t1 = Automata.isterminal(idxA, st)
-            lhs₂, _ = Automata.value(st)
-            lb = length(lhs₂) - length(btsearch.tape) + 1
+        tests = map(btsearch(lhs₁[2:end])) do r
+            lhs₂, _ = r
+            t1 = Automata.isterminal(idxA, last(btsearch.history))
+            lb = length(lhs₂) - length(btsearch.history) + 1
             t2 = lb ≥ 1
             t3 = lb < length(lhs₂)
             t4 = lhs₁[end-lb+1:end] == lhs₂[1:lb]

--- a/test/backtrack.jl
+++ b/test/backtrack.jl
@@ -15,7 +15,7 @@
             (a * b * a * B)^n => ε,
         ]
 
-        RewritingSystem(eqns, LenLex(Al))
+        RewritingSystem(eqns, LenLex(Al), reduced = true)
     end
 
     a, b, B = [Word{UInt8}([i]) for i in 1:3]
@@ -70,7 +70,7 @@
             (a * b * a * B)^n => ε,
         ]
 
-        knuthbendix(RewritingSystem(eqns, LenLex(Al)))
+        knuthbendix(RewritingSystem(eqns, LenLex(Al), reduced = true))
     end
 
     idxA = Automata.IndexAutomaton(R)

--- a/test/gapdoc_examples.jl
+++ b/test/gapdoc_examples.jl
@@ -1,0 +1,138 @@
+@testset "GAPDoc Examples" begin
+    @testset "Example 1: Alt(4)" begin
+        rws = RWS_Alt4()
+        R = knuthbendix(rws)
+        @test KnuthBendix.nrules(R) == 12
+        ia = Automata.IndexAutomaton(R)
+        oracle = Automata.LoopSearchOracle()
+        bs = Automata.BacktrackSearch(ia, oracle)
+        @test isnothing(iterate(bs(one(a))))
+
+        @test oracle.n_visited == 12
+        @test oracle.max_depth == 3
+
+        bs2 = Automata.BacktrackSearch(ia, Automata.IrreducibleWordsOracle())
+        irr_w = collect(bs2)
+        @test length(irr_w) == oracle.n_visited
+        @test maximum(length, irr_w) == oracle.max_depth
+
+        cert = Automata.infiniteness_certificate(ia)
+        @test isone(cert.prefix)
+        @test isone(cert.suffix)
+        @test isfinite(ia)
+        @test Automata.nirreducible_words(ia) == 12
+    end
+
+    @testset "Example 2: Fib(2,5)" begin
+        rws = RWS_Fib2_Monoid(5)
+        R = knuthbendix(rws)
+        @test KnuthBendix.nrules(R) == 24
+        ia = Automata.IndexAutomaton(R)
+        @test Automata.nirreducible_words(ia) == 12
+
+        rws2 = RWS_Fib2_Monoid_Recursive(5)
+        R2 = knuthbendix(rws2)
+        @test KnuthBendix.nrules(R2) == 5
+        ia2 = Automata.IndexAutomaton(R2)
+        @test Automata.nirreducible_words(ia2) == 12
+
+        irr_w = Automata.irreducible_words(ia2)
+        a = irr_w[2]
+        @test irr_w == [a^i for i in 0:11]
+    end
+
+    @testset "Example 3: Heisenberg group" begin
+        rws = RWS_Heisenberg()
+        R = knuthbendix(rws)
+        @test KnuthBendix.nrules(R) == 18
+
+        ia = Automata.IndexAutomaton(R)
+        @test !isfinite(ia)
+        try
+            Automata.nirreducible_words(ia)
+        catch err
+            @test err isa InexactError
+        end
+
+        res = Automata.infiniteness_certificate(ia)
+        @test isone(res.prefix)
+        @test !isone(res.suffix)
+        @test !isfinite(ia)
+
+        for k in 1:20
+            w_k = res.prefix * res.suffix^k
+            @test KnuthBendix.rewrite(w_k, ia) == w_k
+        end
+
+        x, X, y, Y, z, Z = [Word([i]) for i in 1:length(alphabet(rws))]
+
+        zyx = z * y * x
+        @test KnuthBendix.rewrite(zyx, R) == x * y * z^2
+        @test KnuthBendix.rewrite(x * y * z^2, R) == x * y * z^2
+    end
+
+    @testset "Example 4: Nilpotency" begin
+        alph = let letters = Symbol[]
+            for l in 'h':-1:'a'
+                push!(letters, Symbol(l))
+                push!(letters, Symbol(uppercase(l)))
+            end
+            Alphabet(
+                letters,
+                [isodd(i) ? i + 1 : i - 1 for i in 1:length(letters)],
+            )
+        end
+
+        h, g, f, e, d, c, b, a = [Word([i]) for i in 1:2:length(alph)]
+        rels = let A = alph
+            Comm(a, b) = inv(a, A) * inv(b, A) * a * b
+            [
+                (Comm(b, a), c),
+                (Comm(c, a), d),
+                (Comm(d, a), e),
+                (Comm(e, b), f),
+                (Comm(f, a), g),
+                (Comm(g, b), h),
+                (Comm(g, a), one(g)),
+                (Comm(c, b), one(c)),
+                (Comm(e, a), one(e)),
+            ]
+        end
+
+        sett = KnuthBendix.Settings(
+            max_rules = 400,
+            stack_size = 100,
+            confluence_delay = 40,
+        )
+
+        rws = KnuthBendix.RewritingSystem(rels, KnuthBendix.Recursive(alph))
+        @time let R = rws
+            KnuthBendix.reduce!(R)
+            i = 10
+            while !isempty(KnuthBendix.check_confluence(R))
+                @time R = knuthbendix(R, sett)
+                # this is hacking, todo: implement using Settings.max_length_lhs
+                @info KnuthBendix.nrules(R)
+                filter!(r -> length(r.lhs) < i && length(r.rhs) < i, R.rwrules)
+                @info KnuthBendix.nrules(R)
+                append!(R.rwrules, R.rules_orig)
+                R.reduced = false
+                R.confluent = false
+                KnuthBendix.reduce!(R)
+                @info KnuthBendix.nrules(R)
+            end
+        end
+
+        #=
+        R = knuthbendix(
+            rws,
+            KnuthBendix.Settings(
+                max_rules = 1000,
+                stack_size = 100,
+                confluence_delay = 40,
+                verbosity = 2,
+            ),
+        )
+        =#
+    end
+end

--- a/test/gapdoc_examples.jl
+++ b/test/gapdoc_examples.jl
@@ -6,7 +6,7 @@
         ia = Automata.IndexAutomaton(R)
         oracle = Automata.LoopSearchOracle()
         bs = Automata.BacktrackSearch(ia, oracle)
-        @test isnothing(iterate(bs(one(a))))
+        @test isnothing(iterate(bs(one(KnuthBendix.word_type(R)))))
 
         @test oracle.n_visited == 12
         @test oracle.max_depth == 3

--- a/test/kbs.jl
+++ b/test/kbs.jl
@@ -7,10 +7,10 @@
 
     a, b, A, B = [Word([i]) for i in 1:length(KnuthBendix.alphabet(lenlex))]
 
-    R = RewritingSystem([a * b => b * a], lenlex) # ℤ²
+    R = RewritingSystem([(a * b, b * a)], lenlex) # ℤ²
 
     RC = RewritingSystem(
-        [a * b => b * a, b * A => A * b, B * a => a * B, B * A => A * B],
+        [(a * b, b * a), (b * A, A * b), (B * a, a * B), (B * A, A * B)],
         lenlex,
     ) # ℤ² confluent
 

--- a/test/kbs1.jl
+++ b/test/kbs1.jl
@@ -69,7 +69,6 @@
             b * a * B * a => B * a * b,
         ],
         lenlexordB,
-        bare = false,
     )
 
     @test KnuthBendix.irreduciblesubsystem(rsb) == [

--- a/test/kbs1.jl
+++ b/test/kbs1.jl
@@ -7,9 +7,9 @@
     a, A, b, B = [Word([i]) for i in 1:4]
     ε = one(a)
 
-    rs = RewritingSystem([b * a => a * b], lenlexord)
+    rs = RewritingSystem([(b * a, a * b)], lenlexord)
     rsc = RewritingSystem(
-        [b * a => a * b, b * A => A * b, B * a => a * B, B * A => A * B],
+        [(b * a, a * b), (b * A, A * b), (B * a, a * B), (B * A, A * B)],
         lenlexord,
     )
     @test KnuthBendix.irreducible_subsystem(rsc) ==
@@ -53,20 +53,20 @@
 
     rsb = RewritingSystem(
         [
-            b * b * b => ε,
-            (a * b)^3 => ε,
-            b * b => B,
-            b * a * b * a * b => a,
-            a * b * a * b * a => B,
-            B * B => b,
-            b * a * b * a => a * B,
-            a * b * a * b => B * a,
-            b * a * b => a * B * a,
-            B * a * B => a * b * a,
-            B * a * b * a => b * a * B,
-            a * b * a * B => B * a * b,
-            a * B * a * b => b * a * B,
-            b * a * B * a => B * a * b,
+            (b * b * b, ε),
+            ((a * b)^3, ε),
+            (b * b, B),
+            (b * a * b * a * b, a),
+            (a * b * a * b * a, B),
+            (B * B, b),
+            (b * a * b * a, a * B),
+            (a * b * a * b, B * a),
+            (b * a * b, a * B * a),
+            (B * a * B, a * b * a),
+            (B * a * b * a, b * a * B),
+            (a * b * a * B, B * a * b),
+            (a * B * a * b, b * a * B),
+            (b * a * B * a, B * a * b),
         ],
         lenlexordB,
     )

--- a/test/kbs1.jl
+++ b/test/kbs1.jl
@@ -12,7 +12,7 @@
         [b * a => a * b, b * A => A * b, B * a => a * B, B * A => A * B],
         lenlexord,
     )
-    @test KnuthBendix.irreduciblesubsystem(rsc) ==
+    @test KnuthBendix.irreducible_subsystem(rsc) ==
           [a * A, A * a, b * B, B * b, b * a, b * A, B * a, B * A]
 
     rls = collect(KnuthBendix.rules(rs))
@@ -71,7 +71,7 @@
         lenlexordB,
     )
 
-    @test KnuthBendix.irreduciblesubsystem(rsb) == [
+    @test KnuthBendix.irreducible_subsystem(rsb) == [
         a * a,
         b * B,
         B * b,

--- a/test/rewriting.jl
+++ b/test/rewriting.jl
@@ -64,6 +64,8 @@
         Z = empty(R)
 
         @test R isa RewritingSystem
+        @test !isconfluent(R)
+        @test !KnuthBendix.isreduced(R)
 
         @test R !== Z
         @test isempty(Z)

--- a/test/rewriting.jl
+++ b/test/rewriting.jl
@@ -57,7 +57,7 @@
     @testset "Rewriting System operations" begin
         ord = LenLex(Alphabet([:a, :A, :b, :B]))
         R = RewritingSystem(
-            [a * A => ε, A * a => ε, b * B => ε, B * b => ε, a * b => b * a],
+            [(a * A, ε), (A * a, ε), (b * B, ε), (B * b, ε), (a * b, b * a)],
             ord,
         )
 

--- a/test/rewriting.jl
+++ b/test/rewriting.jl
@@ -55,10 +55,10 @@
     end
 
     @testset "Rewriting System operations" begin
+        ord = LenLex(Alphabet([:a, :A, :b, :B]))
         R = RewritingSystem(
             [a * A => ε, A * a => ε, b * B => ε, B * b => ε, a * b => b * a],
-            lenlexord,
-            bare = true,
+            ord,
         )
 
         Z = empty(R)
@@ -71,7 +71,7 @@
 
         push!(Z, KnuthBendix.Rule(b * B => ε))
         @test collect(KnuthBendix.rules(Z)) == [KnuthBendix.Rule(b * B => ε)]
-        @test KnuthBendix.ordering(Z) == lenlexord
+        @test KnuthBendix.ordering(Z) == ord
 
         KnuthBendix.deactivate!(first(KnuthBendix.rules(Z)))
         @test isempty(collect(KnuthBendix.rules(Z)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,11 +21,13 @@ include("abstract_words.jl")
     include("gapdoc_examples.jl")
     include("kbmag_parsing.jl")
 
-    DocMeta.setdocmeta!(
-        KnuthBendix,
-        :DocTestSetup,
-        :(using KnuthBendix; import Base.Order: lt);
-        recursive = true,
-    )
-    doctest(KnuthBendix)
+    if !haskey(ENV, "CI")
+        DocMeta.setdocmeta!(
+            KnuthBendix,
+            :DocTestSetup,
+            :(using KnuthBendix; import Base.Order: lt);
+            recursive = true,
+        )
+        doctest(KnuthBendix)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ include("abstract_words.jl")
     include("rws_examples.jl")
     include("test_examples.jl")
 
+    include("gapdoc_examples.jl")
     include("kbmag_parsing.jl")
 
     DocMeta.setdocmeta!(

--- a/test/rws_examples.jl
+++ b/test/rws_examples.jl
@@ -155,9 +155,9 @@ end
 RWS_Example_6_6() = RWS_Example_237_abaB(8)
 
 function RWS_Exercise_6_1(n)
-    Al = Alphabet(['a', 'b'])
+    Al = Alphabet([:a, :b])
 
-    a, b = Word.([i] for i in 1:2)
+    a, b = Word.([i] for i in 1:length(Al))
     ε = one(a)
 
     eqns = [a^2 => ε, b^3 => ε, (a * b)^n => ε]

--- a/test/rws_examples.jl
+++ b/test/rws_examples.jl
@@ -6,7 +6,7 @@ function RWS_Example_5_1()
     ε = one(a)
 
     R = RewritingSystem(
-        [b * a => a * b],
+        [(b * a, a * b)],
         LenLex(Al, order = ['a', 'A', 'b', 'B']),
     )
 
@@ -23,7 +23,7 @@ function RWS_Example_5_2()
     ε = one(a)
 
     R = RewritingSystem(
-        [b * a => a * b],
+        [(b * a, a * b)],
         LenLex(Al, order = ['a', 'b', 'A', 'B']),
     )
 
@@ -38,7 +38,7 @@ function RWS_Example_5_3()
     a, b = Word.([i] for i in 1:2)
     ε = one(a)
 
-    R = RewritingSystem([a^2 => ε, b^3 => ε, (a * b)^3 => ε], LenLex(Al))
+    R = RewritingSystem([(a^2, ε), (b^3, ε), ((a * b)^3, ε)], LenLex(Al))
 
     return R
 end
@@ -50,7 +50,7 @@ function RWS_Example_5_4()
     a, b, B = Word.([i] for i in 1:3)
     ε = one(a)
 
-    R = RewritingSystem([a^2 => ε, b^3 => ε, (a * b)^3 => ε], LenLex(Al))
+    R = RewritingSystem([(a^2, ε), (b^3, ε), ((a * b)^3, ε)], LenLex(Al))
 
     return R
 end
@@ -64,7 +64,7 @@ function RWS_Example_5_5()
     a, b, c, A, B, C = [Word([i]) for i in 1:6]
     ε = one(a)
 
-    eqns = [c * a => a * c, c * b => b * c, b * a => a * b * c]
+    eqns = [(c * a, a * c), (c * b, b * c), (b * a, a * b * c)]
 
     R = RewritingSystem(
         eqns,
@@ -86,7 +86,7 @@ function RWS_Example_5_5_rec()
     a, b, c, A, B, C = [Word([i]) for i in 1:6]
     ε = one(a)
 
-    eqns = [c * a => a * c, c * b => b * c, b * a => a * b * c]
+    eqns = [(c * a, a * c), (c * b, b * c), (b * a, a * b * c)]
 
     R = RewritingSystem(
         eqns,
@@ -102,11 +102,11 @@ function RWS_Example_6_4()
     a, b, B = Word.([i] for i in 1:3)
     ε = one(a)
     eqns = [
-        a * a => ε,
-        b * B => ε,
-        b^3 => ε,
-        (a * b)^7 => ε,
-        (a * b * a * B)^4 => ε,
+        (a * a, ε),
+        (b * B, ε),
+        (b^3, ε),
+        ((a * b)^7, ε),
+        ((a * b * a * B)^4, ε),
     ]
 
     R = RewritingSystem(eqns, LenLex(Al))
@@ -121,11 +121,11 @@ function RWS_Example_6_5()
     ε = one(a)
     eqns =
         KnuthBendix.Rule.([
-            a * a => ε,
-            b * B => ε,
-            b^2 => B,
-            (B * a)^3 * B => (a * b)^3 * a,
-            (b * a * B * a)^2 => (a * b * a * B)^2,
+            (a * a, ε),
+            (b * B, ε),
+            (b^2, B),
+            ((B * a)^3 * B, (a * b)^3 * a),
+            ((b * a * B * a)^2, (a * b * a * B)^2),
         ])
 
     R = RewritingSystem(eqns, LenLex(Al))
@@ -140,12 +140,12 @@ function RWS_Example_237_abaB(n)
     ε = one(a)
 
     eqns = [
-        b * B => ε,
-        B * b => ε,
-        a^2 => ε,
-        b^3 => ε,
-        (a * b)^7 => ε,
-        (a * b * a * B)^n => ε,
+        (b * B, ε),
+        (B * b, ε),
+        (a^2, ε),
+        (b^3, ε),
+        ((a * b)^7, ε),
+        ((a * b * a * B)^n, ε),
     ]
 
     R = RewritingSystem(eqns, LenLex(Al))
@@ -160,7 +160,7 @@ function RWS_Exercise_6_1(n)
     a, b = Word.([i] for i in 1:length(Al))
     ε = one(a)
 
-    eqns = [a^2 => ε, b^3 => ε, (a * b)^n => ε]
+    eqns = [(a^2, ε), (b^3, ε), ((a * b)^n, ε)]
 
     R = RewritingSystem(eqns, LenLex(Al))
     return R
@@ -188,14 +188,14 @@ function RWS_Closed_Orientable_Surface(n)
     end
 
     ε = one(Word{UInt16})
-    rules = Pair{typeof(ε),typeof(ε)}[]
+    rules = Tuple{typeof(ε),typeof(ε)}[]
     word = Int[]
 
     for i in reverse(1:n)
         x = 4 * i
         append!(word, [x, x - 2, x - 1, x - 3])
     end
-    push!(rules, Word(word) => ε)
+    push!(rules, (Word(word), ε))
     R = RewritingSystem(rules, Recursive(Al, order = reverse(ltrs)))
 
     return R
@@ -239,13 +239,13 @@ function RWS_Coxeter_group_cube()
         v1, v2 = [first(e)], [last(e)]
         s1, s2, s12 = S[v1], S[v2], S[e]
         return [ # (1)(2) → (12), (2)(1) → (12)
-            s1 * s2 => s12,
-            s2 * s1 => s12,
-            #(1)(12) → (2)   (2)(12) → (1) (12)(1) → (2) (12)(2) → (1)
-            s1 * s12 => s2,
-            s2 * s12 => s1,
-            s12 * s1 => s2,
-            s12 * s2 => s1,
+            (s1 * s2, s12),
+            (s2 * s1, s12),
+            #(1)(12) → (2)   (2)(12) → (1)   (12)(1) → (2)   (12)(2) → (1)
+            (s1 * s12, s2),
+            (s2 * s12, s1),
+            (s12 * s1, s2),
+            (s12 * s2, s1),
         ]
     end
 
@@ -258,7 +258,7 @@ function RWS_Coxeter_group_cube()
                 haskey(S, edge) || reverse!(edge)
                 if haskey(S, edge)
                     # (12)(13) → (23)
-                    push!(rels2, S[e] * S[f] => S[edge])
+                    push!(rels2, (S[e] * S[f], S[edge]))
                 end
             end
         end
@@ -275,7 +275,7 @@ function RWS_Baumslag_Solitar(m, n)
     x, X, y, Y = [Word([Al[l]]) for l in ltrs]
 
     R = RewritingSystem(
-        [y * x^n * Y => x^m],
+        [(y * x^n * Y, x^m)],
         WreathOrder(Al, levels = [1, 2, 3, 4]),
     )
 

--- a/test/rws_examples.jl
+++ b/test/rws_examples.jl
@@ -162,7 +162,7 @@ function RWS_Exercise_6_1(n)
 
     eqns = [a^2 => ε, b^3 => ε, (a * b)^n => ε]
 
-    R = RewritingSystem(eqns, LenLex(Al), bare = true)
+    R = RewritingSystem(eqns, LenLex(Al))
     return R
 end
 

--- a/test/rws_examples.jl
+++ b/test/rws_examples.jl
@@ -267,3 +267,17 @@ function RWS_Coxeter_group_cube()
 
     return RewritingSystem(vcat(rels...), wtlex)
 end
+
+function RWS_Baumslag_Solitar(m, n)
+    ltrs = [:x, :X, :y, :Y]
+    Al = Alphabet(ltrs, [2, 1, 4, 3])
+
+    x, X, y, Y = [Word([Al[l]]) for l in ltrs]
+
+    R = RewritingSystem(
+        [y * x^n * Y => x^m],
+        WreathOrder(Al, levels = [1, 2, 3, 4]),
+    )
+
+    return R
+end

--- a/test/rws_examples.jl
+++ b/test/rws_examples.jl
@@ -281,3 +281,41 @@ function RWS_Baumslag_Solitar(m, n)
 
     return R
 end
+
+function RWS_Alt4()
+    alph = Alphabet([:a, :A, :b, :B], [2, 1, 4, 3])
+
+    a, b = Word([alph[:a]]), Word([alph[:b]])
+    rels = [(a^2, one(a)), (b^3, one(a)), ((a * b)^3, one(a))]
+
+    return RewritingSystem(rels, LenLex(alph))
+end
+
+function RWS_Fib2_Monoid(n)
+    alph = Alphabet([Symbol('a', i) for i in 1:n])
+    a = [Word([i]) for i in 1:length(alph)]
+    rels = [(a[mod1(i, n)] * a[mod1(i + 1, n)], a[mod1(i + 2, n)]) for i in 1:n]
+
+    return RewritingSystem(rels, LenLex(alph))
+end
+
+function RWS_Fib2_Monoid_Recursive(n)
+    alph = Alphabet([Symbol('a', i) for i in 1:n])
+    a = [Word([i]) for i in 1:length(alph)]
+    rels = [(a[mod1(i, n)] * a[mod1(i + 1, n)], a[mod1(i + 2, n)]) for i in 1:n]
+
+    return RewritingSystem(rels, Recursive(alph))
+end
+
+function RWS_Heisenberg()
+    alph = Alphabet([:x, :X, :y, :Y, :z, :Z])
+    for (a, A) in ((:x, :X), (:y, :Y), (:z, :Z))
+        KnuthBendix.setinverse!(alph, a, A)
+    end
+    x, X, y, Y, z, Z = [Word([i]) for i in 1:length(alph)]
+    eqns =
+        [(Y * X * y * x, z), (Z * X * z * x, one(x)), (Z * Y * z * y, one(y))]
+    ord = KnuthBendix.WreathOrder(alph, levels = [6, 5, 4, 3, 2, 1])
+
+    return RewritingSystem(eqns, ord)
+end

--- a/test/rws_examples.jl
+++ b/test/rws_examples.jl
@@ -119,14 +119,13 @@ function RWS_Example_6_5()
 
     a, b, B = Word.([i] for i in 1:3)
     ε = one(a)
-    eqns =
-        KnuthBendix.Rule.([
+    eqns = [
             (a * a, ε),
             (b * B, ε),
             (b^2, B),
             ((B * a)^3 * B, (a * b)^3 * a),
             ((b * a * B * a)^2, (a * b * a * B)^2),
-        ])
+    ]
 
     R = RewritingSystem(eqns, LenLex(Al))
     return R

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -192,6 +192,7 @@ end
         RWS_Example_6_5(),
         RWS_Closed_Orientable_Surface(4),
         # RWS_Example_237_abaB(8), # same as RWS_Example_6_6()
+        RWS_Baumslag_Solitar(3, 2),
     ]
         rws = KnuthBendix.knuthbendix2(R)
         R = KnuthBendix.knuthbendix(

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -178,6 +178,18 @@ end
 
     R = RWS_Coxeter_group_cube()
     test_kbs2_methods(R, kbs2methods, 205, max_rules = 300)
+
+    R = RWS_Alt4()
+    test_kbs2_methods(R, kbs2methods, 12)
+
+    R = RWS_Fib2_Monoid(5)
+    test_kbs2_methods(R, kbs2methods, 24)
+
+    R = RWS_Fib2_Monoid_Recursive(5)
+    test_kbs2_methods(R, kbs2methods, 5)
+
+    R = RWS_Heisenberg()
+    test_kbs2_methods(R, kbs2methods, 18)
 end
 
 @testset "KBS-automata" begin
@@ -193,6 +205,10 @@ end
         RWS_Closed_Orientable_Surface(4),
         # RWS_Example_237_abaB(8), # same as RWS_Example_6_6()
         RWS_Baumslag_Solitar(3, 2),
+        RWS_Alt4(),
+        RWS_Fib2_Monoid(5),
+        RWS_Fib2_Monoid_Recursive(5),
+        RWS_Heisenberg(),
     ]
         rws = KnuthBendix.knuthbendix2(R)
         R = KnuthBendix.knuthbendix(

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -11,11 +11,12 @@
           collect(KnuthBendix.rules(rws))[1:5]
 
     R = RWS_Example_5_2()
-    rws = @test_logs (:warn,) knuthbendix(
+    rws = knuthbendix(
         KnuthBendix.KBS1AlgPlain(),
         R,
         KnuthBendix.Settings(max_rules = 100),
     )
+    @test KnuthBendix.isreduced(rws)
     @test !isconfluent(rws)
     @test KnuthBendix.nrules(rws) > 50 # there could be less rules that 100 in the irreducible rws
 
@@ -101,21 +102,29 @@ end
     end
 
     R = RWS_Example_5_2()
-    @test_logs (:warn,) KnuthBendix.knuthbendix(
+    rws = KnuthBendix.knuthbendix(
         KnuthBendix.KBS2AlgPlain(),
         R,
         KnuthBendix.Settings(max_rules = 50),
     )
-    @test_logs (:warn,) KnuthBendix.knuthbendix(
+    @test KnuthBendix.isreduced(rws)
+    @test !isconfluent(rws)
+
+    rws = KnuthBendix.knuthbendix(
         KnuthBendix.KBS2AlgRuleDel(),
         R,
         KnuthBendix.Settings(max_rules = 50),
     )
-    @test_logs (:warn,) KnuthBendix.knuthbendix(
+    @test KnuthBendix.isreduced(rws)
+    @test !isconfluent(rws)
+
+    rws = KnuthBendix.knuthbendix(
         KnuthBendix.KBS2AlgIndexAut(),
         R,
         KnuthBendix.Settings(max_rules = 50),
     )
+    @test KnuthBendix.isreduced(rws)
+    @test !isconfluent(rws)
 
     R = RWS_Example_5_3()
     rws = KnuthBendix.knuthbendix(KnuthBendix.KBS2AlgPlain(), R)


### PR DESCRIPTION
Externally visible changes:
* remove `bare` kwarg from `RewritingSystem` constructor (it was there for compatibility with the older versions)
* construct `RewritingSystem`s from `Tuples` (relations) rather than `Pairs` (rules)
* add `AbstractRewritingSystem`
* add functions to ask about the language of irreducible words of an `IndexAutomaton`: `Automata.infiniteness_certificate`, `Base.isfinite`, `Automata.irreducible_words`, `Automata.nirreducible_words`.

Internal changes:
* add notion of reduced and confluent to `rws`
* store the defining rules separately in `rws`
* store the alphabet derived rules in `rws`
* add Oracle and rewrite backtrack searches on automata